### PR TITLE
A Vision for WebAssembly Support in Swift

### DIFF
--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -23,7 +23,7 @@ examples of its possible adoption in the Swift toolchain itself. To quote
 This can be applicable not only to Swift macros, but also SwiftPM manifests and plugins.
 
 WebAssembly instruction set has useful properties from a security perspective, as it has
-no interrupts or peripherals access instructions. Access to the underlying system is always done by calling a
+no interrupts or peripherals access instructions. Access to the underlying system is always done by calling an
 explicitly imported functions, implementations for which are provided by an imported WebAssembly module or a WebAssembly
 runtime itself. The runtime has full control over interactions of the virtual machine with the outside world.
 
@@ -32,8 +32,8 @@ and validated by the runtime upfront. Combined with the lack of "jump to address
 instructions that require explicit labels in the same function body, this makes a certain class of attacks impossible to
 execute in a correctly implemented spec-compliant WebAssembly runtime.
 
-In the context of Swift developer tools, arbitrary code execution during build time can be more easily virtualized.
-While Swift macros, SwiftPM manifests, and plugins are sandboxed on Darwin platforms, with Wasm we can also apply strong
+In the context of Swift developer tools, arbitrary code execution during build time can be virtualized with Wasm.
+While Swift macros, SwiftPM manifests, and plugins are sandboxed on Darwin platforms, with Wasm we can provide stronger
 security guarantees on other platforms that have a compatible Wasm runtime available.
 
 WebAssembly instruction set is designed with performance in mind. A WebAssembly module can be JIT-compiled or
@@ -99,11 +99,16 @@ of corresponding build scripts and CI jobs to generate and publish such SDK. Som
 libraries need a Swift SDK for running tests for WASI, so this will benefit the previous point in stabilizing support
 for this platform.
 
-3. As a virtualized embeddable platform, not all system APIs are always available or easy to port to WASI. For example,
+3. Make to easier to evaluate and adopt Wasm with increased API coverage for this platform in Swift core libraries. As a
+virtualized embeddable platform, not all system APIs are always available or easy to port to WASI. For example,
 multi-threading, file system access, and localization need special support in Wasm runtimes and certain amount of
-consideration from a developer adopting these APIs. We should focus on simplifying the adoption and increasing
-API coverage for these features in Swift core libraries.
+consideration from a developer adopting these APIs.
 
 4. Improve support for cross-compilation in Swift and SwiftPM. We can simplify versioning, installation, and overall
 management of Swift SDKs for cross-compilation in general, which is beneficial not only foe WebAssembly, but for all
 platforms.
+
+5. Continue work on Wasm Component Model support in Swift as the Component Model proposal is stabilized. Ensure
+that future versions of WASI are available to Swift developers targeting Wasm. A more ambitious long-term goal to
+consider is making interoperability with Wasm components as smooth as C and C++ interop already is for Swift. With
+a formal specification for Canonical ABI progressing, this goal will become more achievable with time.

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -57,11 +57,6 @@ A standardized set of APIs implemented by a Wasm runtime for interaction with th
 use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc). In fact, the current implementation of
 Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library.
 
-The initial version of WASI (referred to as "Preview 1" or as `wasi_snapshot_preview1` by its module name) was
-inspired by C ABI and POSIX, and WASI libc itself is a fork of [Musl libc](http://musl.libc.org) originally developed for
-Linux. This proved to be limiting with continued development of WASI, especially as it does not necessarily have to
-be constrained by C ABI and POSIX. A more powerful runtime implementation can abstract these away.
-
 At the same time, W3C WebAssembly Working Group was considering multiple proposals for improving the WebAssembly [type
 system](https://github.com/webassembly/interface-types) and
 [module linking](https://github.com/webassembly/module-linking). These were later subsumed into a combined
@@ -74,11 +69,6 @@ The Component Model defines these core concepts:
 - A *component* is a composable container for one or more WebAssembly modules that have a predefined interface;
 - *WebAssembly Interface Types (WIT) language* allows defining contracts between components;
 - *Canonical ABI* is an ABI for types defined by WIT and used by component interfaces in the Component Model.
-
-WIT is a high-level language with
-[an advanced type system](https://component-model.bytecodealliance.org/design/wit.html#built-in-types). It can be
-particularly interesting for Swift, as it allows significantly more Swift APIs to be exposed directly in interfaces of
-Wasm components compiled from Swift.
 
 Preliminary support for WIT has been implemented in
 [the `wit-tool` subcommand](https://github.com/swiftwasm/WasmKit/blob/0.0.3/Sources/WITTool/WITTool.swift) of WasmKit
@@ -108,7 +98,9 @@ consideration from a developer adopting these APIs.
 management of Swift SDKs for cross-compilation in general, which is beneficial not only for WebAssembly, but for all
 platforms.
 
-5. Continue work on Wasm Component Model support in Swift as the Component Model proposal is stabilized. Ensure
+5. Explore and prototype virtualization of SwiftPM manifests/plugins and Swift macros with Wasm.
+
+6. Continue work on Wasm Component Model support in Swift as the Component Model proposal is stabilized. Ensure
 that future versions of WASI are available to Swift developers targeting Wasm. A more ambitious long-term goal to
 consider is making interoperability with Wasm components as smooth as C and C++ interop already is for Swift. With
 a formal specification for Canonical ABI progressing, this goal will become more achievable with time.

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -128,7 +128,7 @@ available externally, imported by a Wasm runtime during the linking phase. The d
 module's imports section. Without `@_extern(wasm)` developers need to rely on C interop to create a declaration in a C
 header using the Clang version of attributes.
 
-* [`@_expose_(wasm)` attribute](https://github.com/apple/swift/pull/68524) that corresponds to Clang's
+* [`@_expose(wasm)` attribute](https://github.com/apple/swift/pull/68524) that corresponds to Clang's
 [`__attribute__((export_name("name")))`](https://clang.llvm.org/docs/AttributeReference.html#export-name), which
 is the counterpart of `@_extern(wasm)` working in the opposite direction. This explicitly makes a Swift declaration
 available outside of the current module, added to its exports section under a given name. Again, the lack of

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -22,8 +22,8 @@ examples of its possible adoption in the Swift toolchain itself. To quote
 
 This can be applicable not only to Swift macros, but also for the evaluation of SwiftPM manifests and plugins.
 
-WebAssembly instruction set has useful properties from a security perspective, as it has
-no interrupts or peripherals access instructions. Access to the underlying system is always done by calling an
+The WebAssembly instruction set has useful properties from a security perspective, as it has
+no interrupts or peripheral access instructions. Access to the underlying system is always done by calling
 explicitly imported functions, implementations for which are provided by an imported WebAssembly module or a WebAssembly
 runtime itself. The runtime has full control over interactions of the virtual machine with the outside world.
 
@@ -85,13 +85,13 @@ ecosystem:
 triples.
 
 2. Allow Swift developers to easily install and build with a Swift SDK for WASI. This requires an implementation
-of corresponding build scripts and CI jobs to generate and publish such SDK. Some parts of Swift toolchain and core
+of corresponding build scripts and CI jobs to generate and publish such SDK. Some parts of the Swift toolchain and core
 libraries need a Swift SDK for running tests for WASI, so this will benefit the previous point in stabilizing support
 for this platform.
 
 3. Make it easier to evaluate and adopt Wasm with increased API coverage for this platform in Swift core libraries. As a
 virtualized embeddable platform, not all system APIs are always available or easy to port to WASI. For example,
-multi-threading, file system access, and localization need special support in Wasm runtimes and certain amount of
+multi-threading, file system access, and localization need special support in Wasm runtimes and a certain amount of
 consideration from a developer adopting these APIs.
 
 4. Improve support for cross-compilation in Swift and SwiftPM. We can simplify versioning, installation, and overall

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -57,7 +57,7 @@ A standardized set of APIs implemented by a Wasm runtime for interaction with th
 use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc). In fact, the current implementation of
 Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library.
 
-Initial version of WASI (referred to as "Preview 1" or as `wasi_snapshot_preview1` by its module name) was
+The initial version of WASI (referred to as "Preview 1" or as `wasi_snapshot_preview1` by its module name) was
 inspired by C ABI and POSIX, and WASI libc itself is a fork of [Musl libc](http://musl.libc.org) originally developed for
 Linux. This proved to be limiting with continued development of WASI, especially as it does not necessarily have to
 be constrained by C ABI and POSIX. A more powerful runtime implementation can abstract these away.
@@ -99,13 +99,13 @@ of corresponding build scripts and CI jobs to generate and publish such SDK. Som
 libraries need a Swift SDK for running tests for WASI, so this will benefit the previous point in stabilizing support
 for this platform.
 
-3. Make to easier to evaluate and adopt Wasm with increased API coverage for this platform in Swift core libraries. As a
+3. Make it easier to evaluate and adopt Wasm with increased API coverage for this platform in Swift core libraries. As a
 virtualized embeddable platform, not all system APIs are always available or easy to port to WASI. For example,
 multi-threading, file system access, and localization need special support in Wasm runtimes and certain amount of
 consideration from a developer adopting these APIs.
 
 4. Improve support for cross-compilation in Swift and SwiftPM. We can simplify versioning, installation, and overall
-management of Swift SDKs for cross-compilation in general, which is beneficial not only foe WebAssembly, but for all
+management of Swift SDKs for cross-compilation in general, which is beneficial not only for WebAssembly, but for all
 platforms.
 
 5. Continue work on Wasm Component Model support in Swift as the Component Model proposal is stabilized. Ensure

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -20,7 +20,7 @@ examples of its possible adoption in the Swift toolchain itself. To quote
 > WebAssembly could provide a way to build Swift macros into binaries that can be distributed and run anywhere,
 > eliminating the need to rebuild them continually.
 
-This can be applicable not only to Swift macros, but also SwiftPM manifests and plugins.
+This can be applicable not only to Swift macros, but also for the evaluation of SwiftPM manifests and plugins.
 
 WebAssembly instruction set has useful properties from a security perspective, as it has
 no interrupts or peripherals access instructions. Access to the underlying system is always done by calling an
@@ -36,7 +36,7 @@ In the context of Swift developer tools, arbitrary code execution during build t
 While Swift macros, SwiftPM manifests, and plugins are sandboxed on Darwin platforms, with Wasm we can provide stronger
 security guarantees on other platforms that have a compatible Wasm runtime available.
 
-WebAssembly instruction set is designed with performance in mind. A WebAssembly module can be JIT-compiled or
+The WebAssembly instruction set is designed with performance in mind. A WebAssembly module can be JIT-compiled or
 compiled on a client machine to an optimized native binary ahead of time. With recently accepted proposals to the Wasm
 specification it now supports features such as SIMD, atomics, multi-threading, and more. A WebAssembly runtime can
 generate a restricted subset of native binary code that implements these features with little performance overhead.
@@ -53,11 +53,11 @@ don't "support" those directly either. Actual implementation of I/O for a hardwa
 system, and for a Wasm module it's provided by a runtime that executes it.
 
 A standardized set of APIs implemented by a Wasm runtime for interaction with the host operating system is called
-[WebAssembly System Interface](https://wasi.dev). A layer on top of WASI that Swift apps compiled to Wasm can already
+[WebAssembly System Interface (WASI)](https://wasi.dev). A layer on top of WASI that Swift apps compiled to Wasm can already
 use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc). In fact, the current implementation of
 Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library.
 
-At the same time, W3C WebAssembly Working Group was considering multiple proposals for improving the WebAssembly [type
+At the same time, the W3C WebAssembly Working Group was considering multiple proposals for improving the WebAssembly [type
 system](https://github.com/webassembly/interface-types) and
 [module linking](https://github.com/webassembly/module-linking). These were later subsumed into a combined
 [Component Model](https://component-model.bytecodealliance.org) proposal thanks to the ongoing work on

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -93,7 +93,7 @@ of corresponding build scripts and CI jobs to generate and publish such SDK. Som
 libraries need a Swift SDK for running tests for WASI, so this will benefit the previous point in stabilizing support
 for this platform.
 
-3. Make it easier to evaluate and adopt Wasm with increased API coverage for this platform in Swift core libraries. As a
+3. Make it easier to evaluate and adopt Wasm with increased API coverage for this platform in the Swift core libraries. As a
 virtualized embeddable platform, not all system APIs are always available or easy to port to WASI. For example,
 multi-threading, file system access, and localization need special support in Wasm runtimes and a certain amount of
 consideration from a developer adopting these APIs.

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -5,7 +5,7 @@
 WebAssembly (abbreviated [Wasm](https://webassembly.github.io/spec/core/intro/introduction.html#wasm)) is a virtual 
 machine instruction set focused on portability, security, and high performance. It is vendor-neutral, designed and
 developed by [W3C](https://w3.org). An implementation of a WebAssembly virtual machine is usually called a
-*WebAssembly runtime*, or an [*embedder*](https://webassembly.github.io/spec/core/intro/overview.html#embedder).
+*WebAssembly runtime*.
 
 One prominent spec-compliant implementation of a Wasm runtime in Swift is [WasmKit](https://github.com/swiftwasm/WasmKit). It is available as a Swift package, supports multiple
 host platforms, and has a simple API for interaction with guest Wasm modules.
@@ -51,9 +51,7 @@ Wasm runtime, removing the overhead of new process setup and IPC infrastructure.
 
 ### WebAssembly System Interface and the Component Model
 
-The WebAssembly instruction set on its own doesn't "support" file I/O or networking, in the same way that ARM64 or x86_64
-don't "support" those directly either. Actual implementation of I/O for a hardware CPU is provided by the operating
-system, and for a Wasm module it's provided by a runtime that executes it.
+The WebAssembly virtual machine has no in-built support for I/O; instead, a Wasm module's access to I/O is dependent entirely upon the runtime that executes it.
 
 A standardized set of APIs implemented by a Wasm runtime for interaction with the host operating system is called
 [WebAssembly System Interface (WASI)](https://wasi.dev). A layer on top of WASI that Swift apps compiled to Wasm can already
@@ -61,7 +59,7 @@ use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc)
 Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library. It is important for WASI support in
 Swift to be as complete as possible to ensure portability of Swift code in the broader Wasm ecosystem.
 
-In the last few years, W3C WebAssembly Working Group considered multiple proposals for improving the WebAssembly
+In the last few years, the W3C WebAssembly Working Group considered multiple proposals for improving the WebAssembly
 [type system](https://github.com/webassembly/interface-types) and
 [module linking](https://github.com/webassembly/module-linking). These were later subsumed into a combined
 [Component Model](https://component-model.bytecodealliance.org) proposal thanks to the ongoing work on
@@ -75,7 +73,7 @@ The Component Model defines these core concepts:
 - *Canonical ABI* is an ABI for types defined by WIT and used by component interfaces in the Component Model.
 
 Preliminary support for WIT has been implemented in
-[the `wit-tool` subcommand](https://github.com/swiftwasm/WasmKit/blob/0.0.3/Sources/WITTool/WITTool.swift) of WasmKit
+[the `wit-tool` subcommand](https://github.com/swiftwasm/WasmKit/blob/0.0.3/Sources/WITTool/WITTool.swift) of the WasmKit
 CLI. Users of this tool can generate `.wit` files from Swift declarations, and vice versa: Swift bindings from `.wit`
 files.
 

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -112,3 +112,24 @@ platforms.
 that future versions of WASI are available to Swift developers targeting Wasm. A more ambitious long-term goal to
 consider is making interoperability with Wasm components as smooth as C and C++ interop already is for Swift. With
 a formal specification for Canonical ABI progressing, this goal will become more achievable with time.
+
+### Proposed Language Features
+
+In our work on Wasm support in Swift we experimented with a few function attributes that could be considered
+as pitches and eventually Swift Evolution proposals, if the community is interested in their wider adoption.
+These attributes allow easier interoperation between Swift code and other Wasm modules linked with it by a Wasm
+runtime.
+
+* [`@_extern(wasm)` attribute](https://github.com/apple/swift/pull/69107) that corresponds to Clang's
+[`__attribute__((import_name("declaration_name")))`](https://clang.llvm.org/docs/AttributeReference.html#export-name)
+and [`__attribute__((import_module("module_name")))`](https://clang.llvm.org/docs/AttributeReference.html#import-module).
+This indicates that function's implementation is not provided together with its declaration in Swift and is
+available externally, imported by a Wasm runtime during the linking phase. The declaration is added to current Wasm
+module's imports section. Without `@_extern(wasm)` developers need to rely on C interop to create a declaration in a C
+header using the Clang version of attributes.
+
+* [`@_expose_(wasm)` attribute](https://github.com/apple/swift/pull/68524) that corresponds to Clang's
+[`__attribute__((export_name("name")))`](https://clang.llvm.org/docs/AttributeReference.html#export-name), which
+is the counterpart of `@_extern(wasm)` working in the opposite direction. This explicitly makes a Swift declaration
+available outside of the current module, added to its exports section under a given name. Again, the lack of
+this attribute in Swift requires use of C headers as a workaround.

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -5,7 +5,7 @@
 WebAssembly (abbreviated [Wasm](https://webassembly.github.io/spec/core/intro/introduction.html#wasm)) is a virtual 
 machine instruction set focused on portability, security, and high performance. It is vendor-neutral, designed and
 developed by [W3C](https://w3.org). An implementation of a WebAssembly virtual machine is usually called a
-*WebAssembly runtime*, or [*embedder*](https://webassembly.github.io/spec/core/intro/overview.html#embedder).
+*WebAssembly runtime*, or an [*embedder*](https://webassembly.github.io/spec/core/intro/overview.html#embedder).
 
 Despite its origins in the browser, it is a general-purpose technology that has use cases in client-side and
 server-side applications and services. WebAssembly support in Swift makes the language more appealing in those settings,
@@ -36,7 +36,7 @@ execute in a correctly implemented spec-compliant WebAssembly runtime.
 
 ### Performance
 
-WebAssembly instruction set is designed with performance in mind. A WebAssembly module can be JIT-interpreted or
+WebAssembly instruction set is designed with performance in mind. A WebAssembly module can be JIT-compiled or
 compiled on a client machine to an optimized native binary ahead of time. With recently accepted proposals to the Wasm
 specification it now supports features such as SIMD, atomics, multi-threading, and more. A WebAssembly runtime can
 generate native binary code that implements these features with little performance overhead.
@@ -62,10 +62,10 @@ Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C lib
 
 ### The WebAssembly Component Model
 
-Initial version of WASI (referred to as "Preview 1" or as `wasi_snapshot_preview1` used by its Wasm module name) was
-inspired by C ABI and POSIX, and WASI libc itself is a fork of a portable [Musl libc](http://musl.libc.org) used on
+Initial version of WASI (referred to as "Preview 1" or as `wasi_snapshot_preview1` by its module name) was
+inspired by C ABI and POSIX, and WASI libc itself is a fork of [Musl libc](http://musl.libc.org) originally developed for
 Linux. This proved to be limiting with continued development of WASI, especially as it does not necessarily have to
-be constrained by C ABI and POSIX, as it can abstract these away in more powerful runtime implementations.
+be constrained by C ABI and POSIX. A more powerful runtime implementation can abstract these away.
 
 At the same time, W3C WebAssembly Working Group was considering multiple proposals for improving the WebAssembly [type
 system](https://github.com/webassembly/interface-types) and

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -48,7 +48,7 @@ Wasm runtime, removing the overhead of new process setup and IPC infrastructure.
 
 ### WebAssembly System Interface and the Component Model
 
-WebAssembly instruction set on its own doesn't "support" file I/O or networking, in the same way that ARM64 or x86_64
+The WebAssembly instruction set on its own doesn't "support" file I/O or networking, in the same way that ARM64 or x86_64
 don't "support" those directly either. Actual implementation of I/O for a hardware CPU is provided by the operating
 system, and for a Wasm module it's provided by a runtime that executes it.
 

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -52,13 +52,13 @@ and `wasm64` "architectures" respectively.
 ### WebAssembly System Interface (WASI)
 
 WebAssembly instruction set on its own doesn't "support" file I/O or networking, in the same way that ARM64 or x86_64
-don't "support" those directly either. Actual implementation of I/O for a hardware CPU is provided by the operating system, and
-for a Wasm module it's provided by a runtime that executes it.
+don't "support" those directly either. Actual implementation of I/O for a hardware CPU is provided by the operating
+system, and for a Wasm module it's provided by a runtime that executes it.
 
-A standardized set of APIs implemented by a Wasm runtime for interaction with the host
-operating system is called [WebAssembly System Interface](https://wasi.dev). A layer on top of WASI that Swift apps compiled to Wasm
-can already use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc). In fact, the current
-implementation of Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library.
+A standardized set of APIs implemented by a Wasm runtime for interaction with the host operating system is called
+[WebAssembly System Interface](https://wasi.dev). A layer on top of WASI that Swift apps compiled to Wasm can already
+use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc). In fact, the current implementation of
+Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library.
 
 ### The WebAssembly Component Model
 
@@ -80,8 +80,10 @@ The Component Model defines these core concepts:
 - *WebAssembly Interface Types (WIT) language* allows defining contracts between components;
 - *Canonical ABI* is an ABI for types defined by WIT and used by component interfaces in the Component Model.
 
-WIT is a high-level language with [an advanced type system](https://component-model.bytecodealliance.org/design/wit.html#built-in-types). It can be particularly interesting for Swift, as it allows significantly more Swift APIs to be exposed directly in interfaces of Wasm
-components compiled from Swift.
+WIT is a high-level language with
+[an advanced type system](https://component-model.bytecodealliance.org/design/wit.html#built-in-types). It can be
+particularly interesting for Swift, as it allows significantly more Swift APIs to be exposed directly in interfaces of
+Wasm components compiled from Swift.
 
 Preliminary support for WIT has been implemented in
 [the `wit-tool` subcommand](https://github.com/swiftwasm/WasmKit/blob/0.0.3/Sources/WITTool/WITTool.swift) of WasmKit

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -7,6 +7,9 @@ machine instruction set focused on portability, security, and high performance. 
 developed by [W3C](https://w3.org). An implementation of a WebAssembly virtual machine is usually called a
 *WebAssembly runtime*, or an [*embedder*](https://webassembly.github.io/spec/core/intro/overview.html#embedder).
 
+One prominent spec-compliant implementation of a Wasm runtime in Swift is [WasmKit](https://github.com/swiftwasm/WasmKit). It is available as a Swift package, supports multiple
+host platforms, and has a simple API for interaction with guest Wasm modules.
+
 An application compiled to a Wasm module can run on any platform that has a Wasm runtime available. Despite its origins
 in the browser, it is a general-purpose technology that has use cases in client-side and
 server-side applications and services. WebAssembly support in Swift makes the language more appealing in those settings,

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -58,10 +58,11 @@ system, and for a Wasm module it's provided by a runtime that executes it.
 A standardized set of APIs implemented by a Wasm runtime for interaction with the host operating system is called
 [WebAssembly System Interface (WASI)](https://wasi.dev). A layer on top of WASI that Swift apps compiled to Wasm can already
 use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc). In fact, the current implementation of
-Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library.
+Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library. It is important for WASI support in
+Swift to be as complete as possible to ensure portability of Swift code in the broader Wasm ecosystem.
 
-At the same time, the W3C WebAssembly Working Group was considering multiple proposals for improving the WebAssembly [type
-system](https://github.com/webassembly/interface-types) and
+In the last few years, W3C WebAssembly Working Group considered multiple proposals for improving the WebAssembly
+[type system](https://github.com/webassembly/interface-types) and
 [module linking](https://github.com/webassembly/module-linking). These were later subsumed into a combined
 [Component Model](https://component-model.bytecodealliance.org) proposal thanks to the ongoing work on
 [WASI Preview 2](https://github.com/WebAssembly/WASI/blob/main/preview2/README.md), which served as playground for
@@ -101,9 +102,7 @@ consideration from a developer adopting these APIs.
 management of Swift SDKs for cross-compilation in general, which is beneficial not only for WebAssembly, but for all
 platforms.
 
-5. Explore and prototype virtualization of SwiftPM manifests/plugins and Swift macros with Wasm.
-
-6. Continue work on Wasm Component Model support in Swift as the Component Model proposal is stabilized. Ensure
+5. Continue work on Wasm Component Model support in Swift as the Component Model proposal is stabilized. Ensure
 that future versions of WASI are available to Swift developers targeting Wasm. A more ambitious long-term goal to
 consider is making interoperability with Wasm components as smooth as C and C++ interop already is for Swift. With
 a formal specification for Canonical ABI progressing, this goal will become more achievable with time.

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -88,3 +88,5 @@ Preliminary support for WIT has been implemented in
 CLI.
 
 ## Goals
+
+TBD

--- a/visions/webassembly.md
+++ b/visions/webassembly.md
@@ -1,0 +1,90 @@
+# A Vision for WebAssembly Support in Swift
+
+## Introduction
+
+WebAssembly (abbreviated [Wasm](https://webassembly.github.io/spec/core/intro/introduction.html#wasm)) is a virtual 
+machine instruction set focused on portability, security, and high performance. It is vendor-neutral, designed and
+developed by [W3C](https://w3.org). An implementation of a WebAssembly virtual machine is usually called a
+*WebAssembly runtime*, or [*embedder*](https://webassembly.github.io/spec/core/intro/overview.html#embedder).
+
+Despite its origins in the browser, it is a general-purpose technology that has use cases in client-side and
+server-side applications and services. WebAssembly support in Swift makes the language more appealing in those settings,
+and also brings it to the browser where it previously wasn't available at all.
+
+### Portability
+
+An application compiled to a Wasm module can run on any platform that has a Wasm runtime available. This is useful not
+only for certain applications and libraries, but for the Swift toolchain itself. To quote
+[a GSoC 2024 idea](https://www.swift.org/gsoc2024/#building-swift-macros-with-webassembly):
+
+> WebAssembly could provide a way to build Swift macros into binaries that can be distributed and run anywhere,
+> eliminating the need to rebuild them continually.
+
+This can be applicable not only to Swift macros, but also SwiftPM manifests and plugins.
+
+### Security
+
+WebAssembly instruction set has useful properties from a security perspective, as it has
+no interrupts or peripherals access instructions. Access to the underlying system is always done by calling a
+explicitly imported functions, implementations for which are provided by an imported WebAssembly module or a WebAssembly
+runtime itself. The runtime has full control over interactions of the virtual machine with the outside world.
+
+WebAssembly code and data live in completely separate address spaces, with all executable code in a given module loaded
+and validated by the runtime upfront. Combined with the lack of "jump to address" and a limited set of control flow
+instructions that require explicit labels in the same function body, this makes a certain class of attacks impossible to
+execute in a correctly implemented spec-compliant WebAssembly runtime.
+
+### Performance
+
+WebAssembly instruction set is designed with performance in mind. A WebAssembly module can be JIT-interpreted or
+compiled on a client machine to an optimized native binary ahead of time. With recently accepted proposals to the Wasm
+specification it now supports features such as SIMD, atomics, multi-threading, and more. A WebAssembly runtime can
+generate native binary code that implements these features with little performance overhead.
+
+### 64-bit Support
+
+WebAssembly specifies support for both 32-bit and 64-bit integers and floats as a baseline. Currently, the most common
+pointer size used by Wasm binaries is 32-bit. A large proportion of Wasm applications and libraries don't need to
+address more than 4 GiB of memory. Support for 64-bit pointers was added to the WebAssembly spec and widely used
+runtimes later as an extension. Wasm binaries utilizing certain pointer width are referred as supporting `wasm32`
+and `wasm64` "architectures" respectively.
+
+### WebAssembly System Interface (WASI)
+
+WebAssembly instruction set on its own doesn't "support" file I/O or networking, in the same way that ARM64 or x86_64
+don't "support" those directly either. Actual implementation of I/O for a hardware CPU is provided by the operating system, and
+for a Wasm module it's provided by a runtime that executes it.
+
+A standardized set of APIs implemented by a Wasm runtime for interaction with the host
+operating system is called [WebAssembly System Interface](https://wasi.dev). A layer on top of WASI that Swift apps compiled to Wasm
+can already use thanks to C interop is [WASI libc](https://github.com/WebAssembly/wasi-libc). In fact, the current
+implementation of Swift stdlib and runtime for `wasm32-unknown-wasi` triple is based on this C library.
+
+### The WebAssembly Component Model
+
+Initial version of WASI (referred to as "Preview 1" or as `wasi_snapshot_preview1` used by its Wasm module name) was
+inspired by C ABI and POSIX, and WASI libc itself is a fork of a portable [Musl libc](http://musl.libc.org) used on
+Linux. This proved to be limiting with continued development of WASI, especially as it does not necessarily have to
+be constrained by C ABI and POSIX, as it can abstract these away in more powerful runtime implementations.
+
+At the same time, W3C WebAssembly Working Group was considering multiple proposals for improving the WebAssembly [type
+system](https://github.com/webassembly/interface-types) and
+[module linking](https://github.com/webassembly/module-linking). These were later subsumed into a combined
+[Component Model](https://component-model.bytecodealliance.org) proposal thanks to the ongoing work on
+[WASI Preview 2](https://github.com/WebAssembly/WASI/blob/main/preview2/README.md), which served as playground for
+the new design.
+
+The Component Model defines these core concepts:
+
+- A *component* is a composable container for one or more WebAssembly modules that have a predefined interface;
+- *WebAssembly Interface Types (WIT) language* allows defining contracts between components;
+- *Canonical ABI* is an ABI for types defined by WIT and used by component interfaces in the Component Model.
+
+WIT is a high-level language with [an advanced type system](https://component-model.bytecodealliance.org/design/wit.html#built-in-types). It can be particularly interesting for Swift, as it allows significantly more Swift APIs to be exposed directly in interfaces of Wasm
+components compiled from Swift.
+
+Preliminary support for WIT has been implemented in
+[the `wit-tool` subcommand](https://github.com/swiftwasm/WasmKit/blob/0.0.3/Sources/WITTool/WITTool.swift) of WasmKit
+CLI.
+
+## Goals


### PR DESCRIPTION
For now this contains an introduction section which doesn't assume any prior knowledge of the Wasm ecosystem. It provides overview of properties of Wasm useful when applied to Swift developer tools specifically. A list of high-level goals is provided, with a short subsection for specific language features that can be proposed in the near term.