### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,9 @@ This repository is not your standard codebase. It houses Swift evolution proposa
 ### New proposals pull requests or major modifications 
 New proposals that follow the [Swift evolution process](process.md) can be submitted as a pull request after the pitch process in the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).
 
-Substantive changes to:
-- existing proposals should only be made with the permission of the proposal authors.  Substantive changes to a proposal in the Accepted or Rejected states are discouraged and require the approval of the appropriate evolution workgroup.  Substantive changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
-- change vision documents require the approval of the appropriate evolution workgroup.
-- documented evolution process require the approval of the Core Team.
+#### Substantive changes
+- changes to existing proposals should only be made with the permission of the proposal authors.
+- changes to a proposal in the Accepted or Rejected states are discouraged and require the approval of the appropriate evolution workgroup.
+- changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
+- changes to vision documents require the approval of the appropriate evolution workgroup.
+- changes to documented evolution process require the approval of the Core Team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,19 @@
-# Contributing to Swift Evolution
+# Welcome to the Swift community! 
 
-<https://www.swift.org/code-of-conduct/>
+Contributions to Swift are welcomed and encouraged! Please see the [Contributing to Swift guide](swift.org/contributing) and check out the [structure of the community](https://www.swift.org/community/#community-structure).
 
-Pull requests that make minor editorial and administrative changes to this repository are always welcome, including fixing typos and grammar mistakes, repairing links, and maintaining document and repository metadata.
+To be a truly great community, Swift needs to welcome developers from all walks of life, with different backgrounds, and with a wide range of experience. A diverse and friendly community will have more great ideas, more unique perspectives, and produce more great code. We will work diligently to make the Swift community welcoming to everyone.
 
-Pull requests that add new proposals must follow the [Swift evolution process](process.md), including the proposal having first been pitched on the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).
+To give clarity of what is expected of our members, Swift has adopted the code of conduct defined by the Contributor Covenant. This document is used across many open source communities, and we think it articulates our values well. For more, see the [Code of Conduct](https://www.swift.org/code-of-conduct/).
 
-Pull requests that make substantive changes to existing proposals should only be made with the permission of the proposal authors.  Substantive changes to a proposal in the Accepted or Rejected states are discouraged and require the approval of the appropriate evolution workgroup.  Substantive changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
+## Contributing to Swift Evolution
 
-Pull requests that add or substantively change vision documents require the approval of the appropriate evolution workgroup.
+This repository is not your standard codebase. It houses Swift evolution proposals and related process documents, mostly composed of markdown and text files. We welcome pull requests to this repo that make minor editorial and administrative changes to this repository are always welcome, including fixing typos and grammar mistakes, repairing links, and maintaining document and repository metadata. The majority of the conversation around Swift's evolution happens on the [forums](https://forums.swift.org/c/evolution/18).
 
-Pull requests that substantively change the documented evolution process require the approval of the Core Team.
+### New proposals pull requests or major modifications 
+New proposals that follow the [Swift evolution process](process.md) can be submitted as a pull request after the pitch process in the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).
+
+Substantive changes to:
+- existing proposals should only be made with the permission of the proposal authors.  Substantive changes to a proposal in the Accepted or Rejected states are discouraged and require the approval of the appropriate evolution workgroup.  Substantive changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
+- change vision documents require the approval of the appropriate evolution workgroup.
+- documented evolution process require the approval of the Core Team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,5 +15,4 @@ This repository is not your standard codebase. It houses Swift evolution proposa
 - Substantive changes to existing proposals require the approval of the appropriate evolution workgroup if the proposal is in an Active Review, Accepted, or Rejected state.
 - New vision documents and substantive changes to existing vision documents require the approval of the appropriate evolution workgroup.
 - Substantive changes to the evolution process require the approval of the Core Team.
-
-Conversations about the substance of a proposal should be held in an appropriate forums thread rather than in PR comments.  This centralizes the discussion and allows more of the community to participate.
+- Conversations about the substance of a proposal should be held in an appropriate forums thread rather than in PR comments.  This centralizes the discussion and allows more of the community to participate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,3 @@ This repository is not your standard codebase. It houses Swift evolution proposa
 - Substantive changes to the evolution process require the approval of the Core Team.
 
 Conversations about the substance of a proposal should be held in an appropriate forums thread rather than in PR comments.  This centralizes the discussion and allows more of the community to participate.
-
-### New proposals pull requests or major modifications 
-New proposals that follow the [Swift evolution process](process.md) can be submitted as a pull request after the pitch process in the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).
-
-#### Substantive changes
-- changes to existing proposals should only be made with the permission of the proposal authors.
-- changes to a proposal in the Accepted or Rejected states are discouraged and require the approval of the appropriate evolution workgroup.
-- changes to a proposal in the Active Review state require the approval of the appropriate evolution workgroup and should be advertised in the review thread.
-- changes to vision documents require the approval of the appropriate evolution workgroup.
-- changes to documented evolution process require the approval of the Core Team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,15 @@ To give clarity of what is expected of our members, Swift has adopted the code o
 
 ## Contributing to Swift Evolution
 
-This repository is not your standard codebase. It houses Swift evolution proposals and related process documents, mostly composed of markdown and text files. We welcome pull requests to this repo that make minor editorial and administrative changes to this repository are always welcome, including fixing typos and grammar mistakes, repairing links, and maintaining document and repository metadata. The majority of the conversation around Swift's evolution happens on the [forums](https://forums.swift.org/c/evolution/18).
+This repository is not your standard codebase. It houses Swift evolution proposals and related process documents, mostly composed of markdown and text files. Pull requests that make minor editorial and administrative changes are always welcome, including fixing typos and grammar mistakes, repairing links, and maintaining document and repository metadata. Other pull requests must follow the [Swift evolution process](process.md):
+
+- New proposals and substantive changes to existing proposals should be [pitched on the evolution forums](https://forums.swift.org/c/evolution/pitches/5) before a PR is opened here.
+- Substantive changes to existing proposals require the permission of the proposal authors.
+- Substantive changes to existing proposals require the approval of the appropriate evolution workgroup if the proposal is in an Active Review, Accepted, or Rejected state.
+- New vision documents and substantive changes to existing vision documents require the approval of the appropriate evolution workgroup.
+- Substantive changes to the evolution process require the approval of the Core Team.
+
+Conversations about the substance of a proposal should be held in an appropriate forums thread rather than in PR comments.  This centralizes the discussion and allows more of the community to participate.
 
 ### New proposals pull requests or major modifications 
 New proposals that follow the [Swift evolution process](process.md) can be submitted as a pull request after the pitch process in the [evolution forums](https://forums.swift.org/c/evolution/pitches/5).


### PR DESCRIPTION
What do you think about an updated file with an added a header with language from [the /swift repo](https://github.com/apple/swift?tab=readme-ov-file#contributing-to-swift )?

Also added some headers for pull requests and a paragraph about the repo + highlighting the forums as the main place for conversation.

None of the process language was changed. Mostly reformatting to style. 