### PR TITLE
Suggestion about the description that "A type that conforms to the `Sendable` protocol is a thread-safe type"

### DIFF
--- a/proposals/0430-transferring-parameters-and-results.md
+++ b/proposals/0430-transferring-parameters-and-results.md
@@ -157,9 +157,10 @@ public func withCheckedContinuation<T>(
 
 ### Sendable Values and Sendable Types
 
-A type that conforms to the `Sendable` protocol is a thread-safe type: values of
-that type can be shared with and used safely from multiple concurrent contexts
-at once without causing data races. If a value does not conform to `Sendable`,
+A type that conforms to the `Sendable` protocol can be used safely from multiple 
+concurrent contexts at once without causing data races since values of 
+that type can be shared with in a thread-safe way or transferred by copying them 
+to avoid sharing. If a value does not conform to `Sendable`,
 Swift must ensure that the value is never used concurrently. The value can still
 be sent between concurrent contexts, but the send must be a complete transfer of
 the value's entire region implying that all uses of the value (and anything


### PR DESCRIPTION
> A type that conforms to the `Sendable` protocol is a thread-safe type

When we talked about the above description, we thought that it's not correct since the type which conforms to `Sendable` is not always thread-safe.

For example, if a non-`Sendable` class which has a `Sendable` struct(e.g. `Array<Int>`) is accessed from multiple concurrent contexts at once and the class calls the struct's `mutating` func, data races could be caused. 

We think that Swift just has a system to avoid data races rather than guaranteeing thread safety for types and it's better to change the description.

We are proposing an amendment. Please check it.
Thank you.