### PR TITLE
fix syntax for example

### DIFF
--- a/proposals/0424-custom-isolation-checking-for-serialexecutor.md
+++ b/proposals/0424-custom-isolation-checking-for-serialexecutor.md
@@ -23,7 +23,7 @@ The following example demonstrates such a situation:
 import Dispatch
 
 actor Caplin {
-  let queue: DispatchSerialQueue(label: "CoolQueue")
+  let queue = DispatchSerialQueue(label: "CoolQueue")
 
   var num: Int // actor isolated state
 
@@ -36,9 +36,9 @@ actor Caplin {
     queue.async {
       // guaranteed to execute on `queue`
       // which is the same as self's serial executor
-      queue.assertIsolated() // CRASH: Incorrect actor executor assumption
-      self.assumeIsolated {  // CRASH: Incorrect actor executor assumption
-        num += 1
+      self.queue.assertIsolated() // CRASH: Incorrect actor executor assumption
+      self.assumeIsolated { caplin in // CRASH: Incorrect actor executor assumption
+        caplin.num += 1
       }
     }
   }

--- a/proposals/0424-custom-isolation-checking-for-serialexecutor.md
+++ b/proposals/0424-custom-isolation-checking-for-serialexecutor.md
@@ -23,7 +23,7 @@ The following example demonstrates such a situation:
 import Dispatch
 
 actor Caplin {
-  let queue = DispatchSerialQueue(label: "CoolQueue")
+  let queue: DispatchSerialQueue = .init(label: "CoolQueue")
 
   var num: Int // actor isolated state
 


### PR DESCRIPTION
I was not able to compile the motivating example with Swift 6. I had to make a few small modifications (including adding an init, which I have omitted for clarify).

This now is compilable, and I *think* retains all the original meaning.