### PR TITLE
Fix a typo in SE-0430.

### DIFF
--- a/proposals/0430-transferring-parameters-and-results.md
+++ b/proposals/0430-transferring-parameters-and-results.md
@@ -370,12 +370,12 @@ struct Y2: P1 {
 }
 ```
 
-### `sending inout` parameters
+### `inout sending` parameters
 
 A `sending` parameter can also be marked as `inout`, meaning that the argument
 value must be in a disconnected region when passed to the function, and the
 parameter value must be in a disconnected region when the function
-returns. Inside the function, the `sending inout` parameter can be merged with
+returns. Inside the function, the `inout sending` parameter can be merged with
 actor-isolated callees or further sent as long as the parameter is
 re-assigned a value in a disconnected region upon function exit.
 


### PR DESCRIPTION
When updating the original proposal, I fixed cases where we had written sending consuming -> consuming sending and sending borrowing -> borrowing sending... but I missed a case where we wrote sending inout instead of inout sending. This just fixes the typo.