### PR TITLE
[SE-0257]: Add link to pitch and review threads, unify metadata

### DIFF
--- a/proposals/0257-elide-comma.md
+++ b/proposals/0257-elide-comma.md
@@ -5,9 +5,7 @@
 * Review Manager: [Ted Kremenek](https://github.com/tkremenek)
 * Status: **Returned for revision**
 * Implementation: [apple/swift#21876](https://github.com/apple/swift/pull/22714)
-* Previous Pitch: [Trailing commas in all expression lists](https://forums.swift.org/t/trailing-commas-in-all-expression-lists/19527)
-* Previous Pitch: [SE-0084 spinoff: Newlines as item separators](https://forums.swift.org/t/se-0084-spinoff-newlines-as-item-separators/2659)
-* Decision Notes: [Rationale](https://forums.swift.org/t/se-0257-eliding-commas-from-multiline-expression-lists/22889/191)
+* Review: ([previous pitch 1](https://forums.swift.org/t/se-0084-spinoff-newlines-as-item-separators/2659)) ([previous pitch 2](https://forums.swift.org/t/trailing-commas-in-all-expression-lists/19527)) ([pitch](https://forums.swift.org/t/pitch-eliding-commas-from-multiline-expression-lists/22558)) ([review](https://forums.swift.org/t/se-0257-eliding-commas-from-multiline-expression-lists/22889)) ([returned for revision](https://forums.swift.org/t/se-0257-eliding-commas-from-multiline-expression-lists/22889/191))
 
 # Introduction
 


### PR DESCRIPTION
This adds the links for the pitch and review forum threads to SE-0257. It also formats the `Status` metadata field according to the current format.

I chose to retain the label "previous pitch" for the links to the earlier pitch threads (instead of, say, "pitch 1", "pitch 2", "pitch 3") because (a) the first previous pitch was years earlier and (b) the second previous pitch was for a different feature (allow trailing commas), which then turned into the real pitch for eliding commas a few months later (I think).