### PR TITLE
Fix typo in proposal 0433-mutex.md

### DIFF
--- a/proposals/0433-mutex.md
+++ b/proposals/0433-mutex.md
@@ -110,7 +110,7 @@ public struct Mutex<State: ~Copyable>: ~Copyable {
 extension Mutex: Sendable where State: ~Copyable {}
   
 extension Mutex where State: ~Copyable {
-  /// Calls the given closure after acquring the lock and then releases
+  /// Calls the given closure after acquiring the lock and then releases
   /// ownership.
   ///
   /// This method is equivalent to the following sequence of code:


### PR DESCRIPTION
This PR corrects a typo in the 0433-mutex.md file, changing "acquring" to "acquiring."

Changes:

Fixed "acquring" to "acquiring" in the documentation.

Thank you for reviewing!