### PR TITLE
[SE-0413] Normalize version number to "6.0"

### DIFF
--- a/proposals/0413-typed-throws.md
+++ b/proposals/0413-typed-throws.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0413](0413-typed-throws.md)
 * Authors: [Jorge Revuelta (@minuscorp)](https://github.com/minuscorp), [Torsten Lehmann](https://github.com/torstenlehmann), [Doug Gregor](https://github.com/DougGregor)
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
-* Status: **Implemented (Swift 6)**
+* Status: **Implemented (Swift 6.0)**
 * Review: [latest pitch](https://forums.swift.org/t/pitch-n-1-typed-throws/67496), [review](https://forums.swift.org/t/se-0413-typed-throws/68507), [acceptance](https://forums.swift.org/t/accepted-se-0413-typed-throws/69099)
 
 ## Introduction


### PR DESCRIPTION
The dashboard filter is currently listing both "6" and "6.0" versions.
<https://www.swift.org/swift-evolution/#?version=6,6.0>

Other proposals were normalized in swiftlang/swift-evolution#2335.

Cc: @DougGregor (author)