### PR TITLE
Change function signatures of `expansion` functions of macros to be synchronous

### DIFF
--- a/proposals/0382-expression-macros.md
+++ b/proposals/0382-expression-macros.md
@@ -92,7 +92,7 @@ public protocol ExpressionMacro: FreestandingMacro {
   static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
-  ) async throws -> ExprSyntax
+  ) throws -> ExprSyntax
 }
 ```
 
@@ -250,7 +250,7 @@ public protocol ExpressionMacro: FreestandingMacro {
   static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
-  ) async throws -> ExprSyntax
+  ) throws -> ExprSyntax
 }
 ```
 
@@ -259,8 +259,6 @@ The `FreestandingMacroExpansionSyntax` protocol is the `swift-syntax` node descr
 Macro definitions should conform to the `ExpressionMacro` protocol and implement their syntactic transformation via `expansion(of:in:)`, returning the new expression as a syntax node.
 
 If the macro expansion cannot proceed for some reason, the `expansion(of:in:)` operation can throw an error rather than try to produce a new syntax node. The compiler will then report the error to the user. More detailed diagnostics can be provided via the macro expansion context.
-
-The macro expansion operation is asynchronous, to account for potentially-asynchronous operations that will eventually be added to `MacroExpansionContext`. For example, operations that require additional communication with the compiler to get types of subexpressions, access files in the program, and so on.
 
 #### `MacroExpansionContext`
 
@@ -567,6 +565,8 @@ Expressions are just one place in the language where macros could be valuable. O
 
 ## Revision History
 
+* Revision after acceptance:
+  * Make the `ExpressionMacro.expansion(of:in:)` requirement non-`async`.
 * Revisions based on review feedback:
   * Switch `@expression` to `@freestanding(expression)` to align with the other macros proposals and vision document.
   * Make the `ExpressionMacro.expansion(of:in:)` requirement `async`.

--- a/proposals/0389-attached-macros.md
+++ b/proposals/0389-attached-macros.md
@@ -71,7 +71,7 @@ public PeerMacro: AttachedMacro {
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
-  ) async throws -> [DeclSyntax]
+  ) throws -> [DeclSyntax]
 }
 ```
 
@@ -163,7 +163,7 @@ protocol MemberMacro: AttachedMacro {
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: some MacroExpansionContext
-  ) async throws -> [DeclSyntax]
+  ) throws -> [DeclSyntax]
 }
 ```
 
@@ -232,7 +232,7 @@ protocol AccessorMacro: AttachedMacro {
     of node: AttributeSyntax,
     providingAccessorsOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
-  ) async throws -> [AccessorDeclSyntax]
+  ) throws -> [AccessorDeclSyntax]
 }
 ```
 
@@ -294,7 +294,7 @@ protocol MemberAttributeMacro: AttachedMacro {
     attachedTo declaration: some DeclGroupSyntax,
     providingAttributesOf member: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
-  ) async throws -> [AttributeSyntax]
+  ) throws -> [AttributeSyntax]
 }
 ```
 
@@ -660,6 +660,8 @@ It might be possible to provide a macro implementation API that is expressed in 
 
 ## Revision History
 
+* Revision after acceptance:
+  * Make the `expansion` requirements non-`async`.
 * After the first pitch:
   * Added conformance macros, to produce conformances
   * Moved the discussion of macro-introduced names from the freestanding macros proposal here.

--- a/proposals/0397-freestanding-declaration-macros.md
+++ b/proposals/0397-freestanding-declaration-macros.md
@@ -323,7 +323,7 @@ public protocol CodeItemMacro: FreestandingMacro {
   static func expansion(
     of node: some FreestandingMacroExpansionSyntax,
     in context: some MacroExpansionContext
-  ) async throws -> [CodeBlockItemSyntax]
+  ) throws -> [CodeBlockItemSyntax]
 }
 ```
 


### PR DESCRIPTION
The different macro proposals have been inconsistent about whether the expansion function should be synchronous or asynchronous.

- Synchronous
  - SE-0415 Function Body Macros
  - SE-0402 Extension Macros
  - SE-0407 Member Macro Conformances
  - SE-0397 Freestanding Declaration Macros (but future directions uses `async` function)
- Async
  - SE-0389 Attached Macros
  - SE-0382 Expression Macros

swift-syntax has always implemented synchronous expansion functions. Update the proposals to consistently use synchronous expansion functions to reflect that.