### PR TITLE
[se0447] edits for Span proposal

### DIFF
--- a/proposals/0447-span-access-shared-contiguous-storage.md
+++ b/proposals/0447-span-access-shared-contiguous-storage.md
@@ -140,21 +140,21 @@ Every time `Span` uses a position parameter, it checks for its validity, unless 
 
 ```swift
 extension Span where Element: ~Copyable {
-  /// Return true if `index` is a valid offset into this `Span`
+  /// Return true if `index` is valid for this `Span`
   ///
   /// - Parameters:
   ///   - index: an index to validate
   /// - Returns: true if `index` is a valid index
   public func boundsContain(_ index: Int) -> Bool
 
-  /// Return true if `indices` is a valid range of offsets into this `Span`
+  /// Return true if `indices` are all valid for this `Span`
   ///
   /// - Parameters:
   ///   - indices: a range of indices to validate
   /// - Returns: true if `indices` is a valid range of indices
   public func boundsContain(_ indices: Range<Int>) -> Bool
 
-  /// Return true if `indices` is a valid range of offsets into this `Span`
+  /// Return true if `indices` are all valid for this `Span`
   ///
   /// - Parameters:
   ///   - indices: a range of indices to validate

--- a/proposals/0447-span-access-shared-contiguous-storage.md
+++ b/proposals/0447-span-access-shared-contiguous-storage.md
@@ -81,7 +81,10 @@ extension Span where Element: ~Copyable {
   public var count: Int { get }
   public var isEmpty: Bool { get }
 
-  public subscript(_ position: Int) -> Element { _read }
+  public typealias Index = Int
+  public var indices: Range<Index> { get }
+  
+  public subscript(_ index: Index) -> Element { _read }
 }
 ```
 
@@ -107,10 +110,20 @@ The following properties, functions and subscripts have direct counterparts in t
 
 ```swift
 extension Span where Element: ~Copyable {
+  /// The number of initialized elements in the span.
   public var count: Int { get }
-  public var isEmpty: Bool { get }
 
-  public subscript(_ position: Int) -> Element { _read }
+  /// A Boolean value indicating whether the span is empty.
+	public var isEmpty: Bool { get }
+
+  /// The type that represents a position in `Span`.
+  public typealias Index = Int
+
+  /// The range of indices valid for this `Span`
+  public var indices: Range<Index> { get }
+
+  /// Accesses the element at the specified position.
+  public subscript(_ position: Index) -> Element { _read }
 }
 ```
 
@@ -122,7 +135,6 @@ The `subscript` mentioned above has always-on bounds checking of its parameter, 
 
 ```swift
 extension Span where Element: ~Copyable {
-  // Unchecked subscripting and extraction
 
   /// Accesses the element at the specified `position`.
   ///
@@ -130,7 +142,7 @@ extension Span where Element: ~Copyable {
   ///
   /// - Parameter position: The offset of the element to access. `position`
   ///     must be greater or equal to zero, and less than `count`.
-  public subscript(unchecked position: Int) -> Element { _read }
+  public subscript(unchecked position: Index) -> Element { _read }
 }
 ```
 
@@ -151,7 +163,7 @@ extension Span where Element: ~Copyable {
   /// Parameters:
   /// - span: a span that may be a subrange of `self`
   /// Returns: A range of offsets within `self`, or `nil`
-  public func indices(of span: borrowing Self) -> Range<Int>?
+  public func indices(of span: borrowing Self) -> Range<Index>?
 }
 ```
 

--- a/proposals/0447-span-access-shared-contiguous-storage.md
+++ b/proposals/0447-span-access-shared-contiguous-storage.md
@@ -172,21 +172,13 @@ extension Span where Element: ~Copyable {
   /// Returns true if the other span represents exactly the same memory
   public func isIdentical(to span: borrowing Self) -> Bool
   
-  /// Returns true if the memory represented by `self` is a subrange of
-  /// the memory represented by `span`
+  /// Returns the indices within `self` where the memory represented by `span`
+  /// is located, or `nil` if `span` is not located within `self`.
   ///
   /// Parameters:
-  /// - span: a span of the same type as `self`
-  /// Returns: whether `self` is a subrange of `span`
-  public func isWithin(_ span: borrowing Self) -> Bool
-  
-  /// Returns the offsets where the memory of `self` is located within
-  /// the memory represented by `span`, or `nil`
-  ///
-  /// Parameters:
-  /// - span: a subrange of `self`
+  /// - span: a span that may be a subrange of `self`
   /// Returns: A range of offsets within `self`, or `nil`
-  public func indicesWithin(_ span: borrowing Self) -> Range<Int>?
+  public func indices(of span: borrowing Self) -> Range<Int>?
 }
 ```
 
@@ -405,9 +397,7 @@ When working with multiple `RawSpan` instances, it is often desirable to know wh
 extension RawSpan {
   public func isIdentical(to span: borrowing Self) -> Bool
   
-  public func isWithin(_ span: borrowing Self) -> Bool
-  
-  public func byteOffsetsWithin(_ span: borrowing Self) -> Range<Int>?
+  public func byteOffsets(of span: borrowing Self) -> Range<Int>?
 }
 ```
 

--- a/proposals/0447-span-access-shared-contiguous-storage.md
+++ b/proposals/0447-span-access-shared-contiguous-storage.md
@@ -163,8 +163,6 @@ extension Span where Element: ~Copyable {
 }
 ```
 
-Note: these function names are not ideal.
-
 ##### Identifying whether a `Span` is a subrange of another:
 
 When working with multiple `Span` instances, it is often desirable to know whether one is identical to or a subrange of another. We include functions to determine whether this is the case, as well as a function to obtain the valid offsets of the subrange within the larger span:

--- a/proposals/0447-span-access-shared-contiguous-storage.md
+++ b/proposals/0447-span-access-shared-contiguous-storage.md
@@ -114,7 +114,7 @@ extension Span where Element: ~Copyable {
 }
 ```
 
-Note that we use a `_read` accessor for the subscript, a requirement in order to `yield` a borrowed non-copyable `Element` (see ["Coroutines"](#Coroutines).) This will be updated to a final syntax at a later time, understanding that we intend the replacement to be source-compatible.
+Note that we use a `_read` accessor for the subscript, a requirement in order to `yield` a borrowed non-copyable `Element` (see ["Coroutines"](#Coroutines).) This yields an element whose lifetime is scoped around this particular access, as opposed to matching the lifetime dependency of the `Span` itself. This is a language limitation we expect to resolve with a followup proposal introducing a new accessor model. The subscript will then be updated to use the new accessor semantics. We expect the updated accessor to be source-compatible, as it will provide a borrowed element with a wider lifetime than a `_read` accessor can provide.
 
 ##### Unchecked access to elements:
 

--- a/proposals/0447-span-access-shared-contiguous-storage.md
+++ b/proposals/0447-span-access-shared-contiguous-storage.md
@@ -231,7 +231,7 @@ Initializers, required for library adoption, will be proposed alongside [lifetim
 
 ##### <a name="Load"></a>Accessing the memory of a `RawSpan`:
 
-`RawSpan` has basic operations to access the contents of its memory: `unsafeLoad(as:)` and `unsafeLoadUnaligned(as:)`. These operations are not type-safe, in that the loaded value returned by the operation can be invalid. Some types have a property that makes this operation safe, but there we don't have a way to [formally identify](#SurjectiveBitPattern) such types at this time.
+`RawSpan` has basic operations to access the contents of its memory: `unsafeLoad(as:)` and `unsafeLoadUnaligned(as:)`:
 
 ```swift
 extension RawSpan {
@@ -277,7 +277,10 @@ extension RawSpan {
   ) -> T
 ```
 
-These functions have counterparts which omit bounds-checking for cases where redundant checks affect performance:
+These operations are not type-safe, in that the loaded value returned by the operation can be invalid, and violate type invariants. Some types have a property that makes the `unsafeLoad(as:)` function safe, but we don't have a way to [formally identify](#SurjectiveBitPattern) such types at this time.
+
+The `unsafeLoad` functions have counterparts which omit bounds-checking for cases where redundant checks affect performance:
+
 ```swift
   /// Returns a new instance of the given type, constructed from the raw memory
   /// at the specified offset.

--- a/proposals/0447-span-access-shared-contiguous-storage.md
+++ b/proposals/0447-span-access-shared-contiguous-storage.md
@@ -360,6 +360,9 @@ extension RawSpan {
 
   /// A Boolean value indicating whether the span is empty.
   public var isEmpty: Bool { get }
+  
+  /// The range of valid byte offsets into this `RawSpan`
+  public var byteOffsets: Range<Int> { get }
 }
 ```
 


### PR DESCRIPTION
Wording updates, and also the API update suggested in https://forums.swift.org/t/74676/17: `isWithin()` is removed, and `indicesWithin()` is changed to `indices(of:)`.
The API change essentially only had feedback from @lorentey, so I take it that it's fine. The polarity of the function is changed as well, with the return value now being relative to the `self` parameter.

An updated toolchain is in https://github.com/swiftlang/swift/pull/76622