### PR TITLE
Fix typo in `0450-swiftpm-package-traits.md`

### DIFF
--- a/proposals/0450-swiftpm-package-traits.md
+++ b/proposals/0450-swiftpm-package-traits.md
@@ -457,7 +457,7 @@ compiler error to detect this during build time.
 
 ```swift
 #if Trait1 && Trait2
-#error("Trait1 and Trait2 are mutuall exclusive")
+#error("Trait1 and Trait2 are mutually exclusive")
 #endif
 ```
 


### PR DESCRIPTION
`mutuall exclusive` -> `mutually exclusive`