### PR TITLE
[SE-0314] Fix typo

### DIFF
--- a/proposals/0314-async-stream.md
+++ b/proposals/0314-async-stream.md
@@ -135,7 +135,7 @@ Alternatively if a source is just an async function (one that represents a backp
 
 ### Creating an `AsyncThrowingStream`
 
-Along with the potentially infinite sequence in the example above, `AsyncSeries` can also adapt APIs like the slightly contrived one below. The `findVegetables` function uses callback closures that are called with each retrieved vegetable, as well as when the vegetables have all been returned or an error occurs.
+Along with the potentially infinite sequence in the example above, `AsyncThrowingStream` can also adapt APIs like the slightly contrived one below. The `findVegetables` function uses callback closures that are called with each retrieved vegetable, as well as when the vegetables have all been returned or an error occurs.
 
 ```swift
 func buyVegetables(


### PR DESCRIPTION
The usage of "`AsyncSeries`" looks like a typo. The term doesn't appear anywhere else in the document. The document does use the word "series" a few times as an alternative to "stream", but using it as an identifier seems wrong.

I replaced "`AsyncSeries`" with "`AsyncThrowingStream`" because it appears in the section on `AsyncThrowingStream`. Replacing it with "`AsyncStream`" would also work, but since this section is about the throwing variant, `AsyncThrowingStream` seems better.