### PR TITLE
[SE-0430] Fix typo.

### DIFF
--- a/proposals/0430-transferring-parameters-and-results.md
+++ b/proposals/0430-transferring-parameters-and-results.md
@@ -340,7 +340,7 @@ protocol P2 {
 
 Following the function subtyping rules in the previous section, a protocol
 requirement with a `sending` parameter may be witnessed by a function with a
-non-`Sendable` typed parameter:
+non-`sending` parameter:
 
 ```swift
 struct X1: P1 {


### PR DESCRIPTION
Should have written 'sending', not 'Sending' here.