### PR TITLE
Mark SE-0450 (package traits) as implemented in 6.1

### DIFF
--- a/proposals/0450-swiftpm-package-traits.md
+++ b/proposals/0450-swiftpm-package-traits.md
@@ -5,7 +5,6 @@
 * Review Manager: [Mishal Shah](https://github.com/shahmishal)
 * Status: **Implemented (Swift 6.1)**
 * Implementation: https://github.com/swiftlang/swift-package-manager/pull/7704, https://github.com/swiftlang/swift-package-manager/pull/7703, https://github.com/swiftlang/swift-package-manager/pull/7702, https://github.com/swiftlang/swift-package-manager/pull/7701, https://github.com/swiftlang/swift-package-manager/pull/7694, https://github.com/swiftlang/swift-package-manager/pull/7689, https://github.com/swiftlang/swift-package-manager/pull/8178
-* Experimental Implementation: Gated on `@_spi(ExperimentalTraits)` in package manifests and `--experimental` prefix for CLI options
 * Review: ([pitch](https://forums.swift.org/t/pitch-package-traits/72191)) ([review](https://forums.swift.org/t/se-0450-package-traits/75598)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0450-package-traits/76705))
 
 ## Introduction

--- a/proposals/0450-swiftpm-package-traits.md
+++ b/proposals/0450-swiftpm-package-traits.md
@@ -3,10 +3,10 @@
 * Proposal: [SE-0450](0450-swiftpm-package-traits.md)
 * Authors: [Franz Busch](https://github.com/FranzBusch), [Max Desiatov](https://github.com/MaxDesiatov)
 * Review Manager: [Mishal Shah](https://github.com/shahmishal)
-* Status: Implemented (Swift 6.1)
+* Status: **Implemented (Swift 6.1)**
 * Implementation: https://github.com/swiftlang/swift-package-manager/pull/7704, https://github.com/swiftlang/swift-package-manager/pull/7703, https://github.com/swiftlang/swift-package-manager/pull/7702, https://github.com/swiftlang/swift-package-manager/pull/7701, https://github.com/swiftlang/swift-package-manager/pull/7694, https://github.com/swiftlang/swift-package-manager/pull/7689, https://github.com/swiftlang/swift-package-manager/pull/8178
 * Experimental Implementation: Gated on `@_spi(ExperimentalTraits)` in package manifests and `--experimental` prefix for CLI options
-* Review: ([pitch](https://forums.swift.org/t/pitch-package-traits/72191)) ([review](https://forums.swift.org/t/se-0450-package-traits/75598))
+* Review: ([pitch](https://forums.swift.org/t/pitch-package-traits/72191)) ([review](https://forums.swift.org/t/se-0450-package-traits/75598)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-se-0450-package-traits/76705))
 
 ## Introduction
 

--- a/proposals/0450-swiftpm-package-traits.md
+++ b/proposals/0450-swiftpm-package-traits.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0450](0450-swiftpm-package-traits.md)
 * Authors: [Franz Busch](https://github.com/FranzBusch), [Max Desiatov](https://github.com/MaxDesiatov)
 * Review Manager: [Mishal Shah](https://github.com/shahmishal)
-* Status: **Accepted**
+* Status: Implemented (Swift 6.1)
 * Implementation: https://github.com/swiftlang/swift-package-manager/pull/7704, https://github.com/swiftlang/swift-package-manager/pull/7703, https://github.com/swiftlang/swift-package-manager/pull/7702, https://github.com/swiftlang/swift-package-manager/pull/7701, https://github.com/swiftlang/swift-package-manager/pull/7694, https://github.com/swiftlang/swift-package-manager/pull/7689, https://github.com/swiftlang/swift-package-manager/pull/8178
 * Experimental Implementation: Gated on `@_spi(ExperimentalTraits)` in package manifests and `--experimental` prefix for CLI options
 * Review: ([pitch](https://forums.swift.org/t/pitch-package-traits/72191)) ([review](https://forums.swift.org/t/se-0450-package-traits/75598))


### PR DESCRIPTION
This feature was cherry-picked to 6.1 with experimental prefixes removed after SE acceptance.