### PR TITLE
Update 0414-region-based-isolation.md

### DIFF
--- a/proposals/0414-region-based-isolation.md
+++ b/proposals/0414-region-based-isolation.md
@@ -321,9 +321,10 @@ Now lets apply these rules to some specific examples in Swift code:
   ```swift
   func captureInClosure() {
     let x = NonSendable()
-    // Regions: [(x)]
-    let closure = { print(x) }
-    // Regions: [(x, closure)]
+    let y = NonSendable()
+    // Regions: [(x), (y)]
+    let closure = { print(x); print(y) }
+    // Regions: [(x, y, closure)]
   }
   ```
 


### PR DESCRIPTION
# Adjusting the code to match the scenario described in the example.

In the example for the case I have modified, it is mentioned that 'x' and 'y' are used.
But in the code given as example, only 'x' is showcased. 
I made a small adjustment to show how 'x' and 'y' end up together in the same region as 'closure'.