### PR TITLE
Update examples in 0458-strict-memory-safety.md

### DIFF
--- a/proposals/0458-strict-memory-safety.md
+++ b/proposals/0458-strict-memory-safety.md
@@ -93,7 +93,6 @@ To suppress these warnings, the expressions involving unsafe code must be marked
 extension Array<Int> {
   func sum() -> Int {
     withUnsafeBufferPointer { buffer in
-      // warning: use of unsafe function 'sumIntBuffer' and unsafe property 'baseAddress'
       unsafe sumIntBuffer(buffer.baseAddress, buffer.count, 0)
     }
   }
@@ -122,10 +121,10 @@ The operation `UnsafeMutableBufferPointer.swapAt` swaps the values at the given 
 
 ```swift
 extension UnsafeMutableBufferPointer {
-  @unsafe public func swapAt(_ i: Element, _ j: Element) {
+  @unsafe public func swapAt(_ i: Index, _ j: Index) {
     guard i != j else { return }
     precondition(i >= 0 && j >= 0)
-    precondition(unsafe i < endIndex && j < endIndex)
+    precondition(i < endIndex && j < endIndex)
     let pi = unsafe (baseAddress! + i)
     let pj = unsafe (baseAddress! + j)
     let tmp = unsafe pi.move()


### PR DESCRIPTION
This change addresses two examples:

1. The text introducing the updated version of the `sum()` example is "The warning-free version of this code is:", but the code sample still includes the warning. This change removes the warning.

2. The `swapAt` implementation has two issues: 
 - the parameters should be of type `Index` (or `Int`?), not `Element`
 - the precondition check that `i` and `j` are before `endIndex` should not have an `unsafe` keyword, since `endIndex` is designated as `@safe`.