### PR TITLE
Pitch for extensible enums

### DIFF
--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -1,0 +1,185 @@
+# Extensible enums
+
+* Proposal: [SE-NNNN](NNNN-extensible-enums.md)
+* Authors: [Cory Benfield](https://github.com/lukasa), [Pavel Yaskevich](https://github.com/xedin), [Franz Busch](https://github.com/FranzBusch)
+* Review Manager: TBD
+* Status: **Awaiting review**
+* Bug: [apple/swift#55110](https://github.com/swiftlang/swift/issues/55110)
+* Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/NNNNN)
+* Upcoming Feature Flag: `ExtensibleEnums`
+* Review: ([pitch](https://forums.swift.org/...))
+
+## Introduction
+
+This proposal addresses the long standing behavioural difference of `enum`s in
+Swift modules compiled with and without library evolution. This makes Swift
+`enum`s vastly more useful in public API of non-resilient Swift libraries.
+
+## Motivation
+
+When Swift was enhanced to add support for "library evolution" mode (henceforth
+called "resilient" mode), the Swift project had to make a number of changes to
+support a movable scale between "maximally evolveable" and "maximally
+performant". This is because it is necessary for an ABI stable library to be
+able to add new features and API surface without breaking pre-existing compiled
+binaries. While by-and-large this was done without introducing feature
+mismatches between the "resilient" and default "non-resilient" language
+dialects, the `@frozen` attribute when applied to enumerations managed to
+introduce a difference. This difference was introduced late in the process of
+evolving SE-0192, and this pitch would aim to address it.
+
+`@frozen` is a very powerful attribute. It can be applied to both structures and
+enumerations. It has a wide ranging number of effects, including exposing their
+size directly as part of the ABI and providing direct access to stored
+properties. However, on enumerations it happens to also exert effects on the
+behaviour of switch statements.
+
+Consider the following simple library to your favourite pizza place:
+
+```swift
+public enum PizzaFlavor {
+    case hawaiian
+    case pepperoni
+    case cheese
+}
+
+public func bakePizza(flavor: PizzaFlavor)
+```
+
+Depending on whether the library is compiled with library evolution mode
+enabled, what the caller can do with the `PizzaFlavor` enum varies. Specifically,
+the behaviour in switch statements changes.
+
+In the _standard_, "non-resilient" mode, users of the library can write
+exhaustive switch statements over the enum `PizzaFlavor`:
+
+```swift
+switch pizzaFlavor {
+case .hawaiian:
+    throw BadFlavorError()
+case .pepperoni:
+    try validateNoVegetariansEating()
+case .cheese:
+    return .delicious
+}
+```
+
+This code will happily compile. If the author of the above switch statement was
+missing a case (perhaps they forgot `.hawaiian` is a flavor), the compiler will
+error, and force the user to either add a `default:` clause, or to express a
+behaviour for the missing case. The term for this is "exhaustiveness": in the
+default "non-resilient" dialect, the Swift compiler will ensure that all switch
+statements over enumerations cover every case that is present.
+
+There is a downside to this mode. If the library wants to add a new flavour
+(maybe `.veggieSupreme`), they are in a bind. If any user anywhere has written
+an exhaustive switch over `PizzaFlavor`, adding this flavor will be an API and
+ABI breaking change, as the compiler will error due to the missing case
+statement for the new enum case.
+
+Because of the implications on ABI and the requirement to be able to evolve
+libraries with public enumerations in their API, the resilient language dialect
+behaves differently. If the library was compiled with `enable-library-evolution`
+turned on, when a user attempts to exhaustively switch over the `PizzaFlavor`
+enum the compiler will emit a warning, encouraging users to add an `@unknown
+default:` clause. Thus, to avoid the warning the user would be forced to
+consider how new enumeration cases should be treated. They may arrive at
+something like this:
+
+```swift
+switch pizzaFlavor {
+case .hawaiian:
+    throw BadFlavorError()
+case .pepperoni:
+    try validateNoVegetariansEating()
+    return .delicious
+case .cheese:
+    return .delicious
+@unknown default:
+    try validateNoVegetariansEating()
+    return .delicious
+}
+```
+
+When a resilient library knows that an enumeration will not be extended, and
+wants to improve the performance of using it, the author can annotate the enum
+with `@frozen`. This annotation has a wide range of effects, but one of its
+effects is to enable callers to perform exhaustive switches over the frozen
+enumeration. Thus, resilient library authors that are interested in the
+exhaustive switching behaviour are able to opt-into it.
+
+However, in Swift today it is not possible for the default, "non-resilient"
+dialect to opt-in to the extensible enumeration behaviour. That is, there is no
+way for a Swift package to be able to evolve a public enumeration without
+breaking the API. This is a substantial limitation, and greatly reduces the
+utility of enumerations in non-resilient Swift. Over the past years, many
+packages ran into this limitation when trying to express APIs using enums. As a
+non-exhaustive list of problems this can cause:
+
+- Using enumerations to represent `Error`s is inadvisable, as if new errors need
+  to be introduced they cannot be added to existing enumerations. This leads to
+  a proliferation of `Error` enumerations. "Fake" enumerations can be made using
+  `struct`s and `static let`s, but these do not work with the nice `Error`
+  pattern-match logic in catch blocks, requiring type casts.
+- Using an enumeration to refer to a group of possible ideas without entirely
+  exhaustively evaluating the set is potentially dangerous, requiring a
+  deprecate-and-replace if any new elements appear.
+- Using an enumeration to represent any concept that is inherently extensible is
+  tricky. For example, `SwiftNIO` uses an enumeration to represent HTTP status
+  codes. If new status codes are added, SwiftNIO needs to either mint new
+  enumerations and do a deprecate-and-replace, or it needs to force these new
+  status codes through the .custom enum case.
+
+This proposal plans to address these limitations on enumerations in
+non-resilient Swift.
+
+## Proposed solution
+
+We propose to introduce a new language feature `ExtensibleEnums` that aligns the
+behaviour of enumerations in both language dialetcs. This will make enumerations
+in packages a safe default and leave maintainers the choice of extending them
+later on.
+
+In modules with the language feature enabled, developers can use the exisiting
+`@frozen` attribute to mark an enumeration as non-extensible. Allowing consumers
+of the module to exhaustively switch over the cases. This makes commiting to the
+API of an enum an active choice for developers.
+
+Modules consuming other modules with the language feature enabled will be forced
+to add an `@unknown default:` case to any switch state for enumerations that are
+not marked with `@frozen`.
+
+Since enabling a language feature applies to the whole module at once we also
+propose adding a new attribute `@extensible` analogous to `@frozen`. This
+attribute allows developers to make a case-by-case decision on each enumeration
+if it should be extensible or not by applying one of the two attributes. The
+language feature `ExtensibleEnums` can be thought of as implicitly adding
+`@extensible` to all enums that are not explicitly marked as `@frozen`.
+
+## Source compatibility
+
+Enabling the language feature `ExtensibleEnums` in a module that contains public
+enumerations is a source breaking change.
+Changing the annotation from `@frozen` to `@extensible` is a source breaking
+change. 
+Changing the annotation from `@extensible` to `@frozen` is a source compatible
+change and will only result in a warning code that used `@unknown default:`
+clause. This allows developers to commit to the API of an enum in a non-source
+breaking way.
+
+## Effect on ABI stability
+
+This attribute does not affect the ABI, as it is a no-op when used in a resilient library.
+
+## Effect on API resilience
+
+This proposal only affects API resilience of non-resilient libraries, by enabling more changes to be made without API breakage.
+
+## Future directions
+
+### Enable `ExtensibleEnums` by default in a future language mode
+
+We believe that extensible enums should be default in the language to remove the
+common pitfall of using enums in public API and only later on realising that
+those can't be extended in an API compatible way. Since this would be a large
+source breaking it must be gated behind a new language mode.

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -59,6 +59,7 @@ case .hawaiian:
     throw BadFlavorError()
 case .pepperoni:
     try validateNoVegetariansEating()
+    return .delicious
 case .cheese:
     return .delicious
 }
@@ -149,8 +150,8 @@ Modules consuming other modules with the language feature enabled will be forced
 to add an `@unknown default:` case to any switch state for enumerations that are
 not marked with `@frozen`. Importantly, this only applies to enums that are
 imported from other modules that are not in the same package. For enums inside
-the same modules of the declaring package switches is still required to be
-exhaustive and doesn't require an `@unknown default:` case.
+the same modules of the declaring package switches are still required to be
+exhaustive and don't require an `@unknown default:` case.
 
 Since enabling a language feature applies to the whole module at once we also
 propose adding a new attribute `@extensible` analogous to `@frozen`. This
@@ -166,6 +167,9 @@ right default choice in both resilient and non-resilient modules and the new
 proposed `@extensible` attribute primiarly exists to give developers a migration
 path.
 
+In non-resilient modules, adding the `@extensible` attribute to non-public enums
+will produce a warning since those enums can only be matched exhaustively.
+
 ## Source compatibility
 
 Enabling the language feature `ExtensibleEnums` in a module that contains public
@@ -176,9 +180,9 @@ Changing the annotation from `@extensible` to `@frozen` is a source compatible
 change and will only result in a warning code that used `@unknown default:`
 clause. This allows developers to commit to the API of an enum in a non-source
 breaking way.
-Adding an `@extensible` annotation is a source breaking change in modules that
-have **not** enabled the `ExtensibleEnums` language features or are compiled
-with resiliency.
+Adding an `@extensible` annotation to an exisitng public enum is a source
+breaking change in modules that have **not** enabled the `ExtensibleEnums`
+language features or are compiled with resiliency.
 
 ## Effect on ABI stability
 

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -289,7 +289,7 @@ are not semantically versioned. This can either be done by using local packages
 or by using _revision locked_ dependencies. The packages in such a setup are
 often considered part of the same logical collection of code and would like to
 follow the same source stability rules as same module or same package code. We
-propose to extend then package manifest to allow overriding the package name
+propose to extend the package manifest to allow overriding the package name
 used by a target.
 
 ```swift
@@ -337,7 +337,7 @@ same unit.
 
 There might still be cases where developers need to consume a module that is
 outside of their control which adopts the `ExtensibleEnums` feature. For such
-cases we propose to introduce a flag `--assume-source-stable-package` that
+cases we propose to introduce a new flag `--assume-source-stable-package` that
 allows assuming modules of a package as source stable. When checking if a switch
 needs to be exhaustive we will check if the code is either in the same module,
 the same package, or if the defining package is assumed to be source stable.

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -1,7 +1,7 @@
 # Extensible enums
 
 * Proposal: [SE-NNNN](NNNN-extensible-enums.md)
-* Authors: [Cory Benfield](https://github.com/lukasa), [Pavel Yaskevich](https://github.com/xedin), [Franz Busch](https://github.com/FranzBusch)
+* Authors: [Pavel Yaskevich](https://github.com/xedin), [Franz Busch](https://github.com/FranzBusch), [Cory Benfield](https://github.com/lukasa)
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Bug: [apple/swift#55110](https://github.com/swiftlang/swift/issues/55110)
@@ -26,7 +26,7 @@ binaries. While by-and-large this was done without introducing feature
 mismatches between the "resilient" and default "non-resilient" language
 dialects, the `@frozen` attribute when applied to enumerations managed to
 introduce a difference. This difference was introduced late in the process of
-evolving SE-0192, and this pitch would aim to address it.
+evolving SE-0192, and this proposal would aim to address it.
 
 `@frozen` is a very powerful attribute. It can be applied to both structures and
 enumerations. It has a wide ranging number of effects, including exposing their
@@ -136,13 +136,13 @@ non-resilient Swift.
 ## Proposed solution
 
 We propose to introduce a new language feature `ExtensibleEnums` that aligns the
-behaviour of enumerations in both language dialetcs. This will make enumerations
+behaviour of enumerations in both language dialects. This will make enumerations
 in packages a safe default and leave maintainers the choice of extending them
 later on.
 
-In modules with the language feature enabled, developers can use the exisiting
-`@frozen` attribute to mark an enumeration as non-extensible. Allowing consumers
-of the module to exhaustively switch over the cases. This makes commiting to the
+In modules with the language feature enabled, developers can use the existing
+`@frozen` attribute to mark an enumeration as non-extensible, allowing consumers
+of the module to exhaustively switch over the cases. This makes committing to the
 API of an enum an active choice for developers.
 
 Modules consuming other modules with the language feature enabled will be forced
@@ -155,6 +155,13 @@ attribute allows developers to make a case-by-case decision on each enumeration
 if it should be extensible or not by applying one of the two attributes. The
 language feature `ExtensibleEnums` can be thought of as implicitly adding
 `@extensible` to all enums that are not explicitly marked as `@frozen`.
+
+In resilient modules, the `@extensible` module doesn't affect API nor ABI since
+the behaviour of enumerations in modules compiled with library evolution mode
+are already extensible by default. We believe that extensible enums are the
+right default choice in both resilient and non-resilient modules and the new
+proposed `@extensible` attribute primiarly exists to give developers a migration
+path.
 
 ## Source compatibility
 

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -136,9 +136,9 @@ non-resilient Swift.
 ## Proposed solution
 
 We propose to introduce a new language feature `ExtensibleEnums` that aligns the
-behaviour of enumerations in both language dialects. This will make enumerations
-in packages a safe default and leave maintainers the choice of extending them
-later on.
+behaviour of enumerations in both language dialects. This will make **public**
+enumerations in packages a safe default and leave maintainers the choice of
+extending them later on.
 
 In modules with the language feature enabled, developers can use the existing
 `@frozen` attribute to mark an enumeration as non-extensible, allowing consumers
@@ -147,7 +147,10 @@ API of an enum an active choice for developers.
 
 Modules consuming other modules with the language feature enabled will be forced
 to add an `@unknown default:` case to any switch state for enumerations that are
-not marked with `@frozen`.
+not marked with `@frozen`. Importantly, this only applies to enums that are
+imported from other modules that are not in the same package. For enums inside
+the same modules of the declaring package switches is still required to be
+exhaustive and doesn't require an `@unknown default:` case.
 
 Since enabling a language feature applies to the whole module at once we also
 propose adding a new attribute `@extensible` analogous to `@frozen`. This
@@ -156,9 +159,9 @@ if it should be extensible or not by applying one of the two attributes. The
 language feature `ExtensibleEnums` can be thought of as implicitly adding
 `@extensible` to all enums that are not explicitly marked as `@frozen`.
 
-In resilient modules, the `@extensible` module doesn't affect API nor ABI since
-the behaviour of enumerations in modules compiled with library evolution mode
-are already extensible by default. We believe that extensible enums are the
+In resilient modules, the `@extensible` attribute doesn't affect API nor ABI
+since the behaviour of enumerations in modules compiled with library evolution
+mode are already extensible by default. We believe that extensible enums are the
 right default choice in both resilient and non-resilient modules and the new
 proposed `@extensible` attribute primiarly exists to give developers a migration
 path.
@@ -189,4 +192,4 @@ This proposal only affects API resilience of non-resilient libraries, by enablin
 We believe that extensible enums should be default in the language to remove the
 common pitfall of using enums in public API and only later on realising that
 those can't be extended in an API compatible way. Since this would be a large
-source breaking it must be gated behind a new language mode.
+source breaking change it must be gated behind a new language mode.

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -231,7 +231,7 @@ Since some modules support compiling in resilient and non-resilient modes,
 developers need a way to mark enums as non-extensible for both. `@nonExtensible`
 produces an error when compiling with resiliency; hence, developers must use
 `@frozen`. To make supporting both modes easier `@frozen` will also work in
-non-resilient modules and make enumerations extensible.
+non-resilient modules and make enumerations non extensible.
 
 ## Source compatibility
 

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -259,6 +259,13 @@ Enums can be used for errors. Catching and pattern matching enums could add
 support for an `@unknown catch` to make pattern matching of typed throws align
 with `switch` pattern matching.
 
+### Allow adding additional associated values
+
+Adding additional associated values to an enum can also be seen as extending it
+and we agree that this is interesting to explore in the future. However, this
+proposal focuses on solving the primary problem of the unusability of public
+enumerations in non-resilient modules.
+
 ## Alternatives considered
 
 ### Only provide the `@extensible` annotation

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -316,7 +316,7 @@ future Swift language mode.
 
 ### Introducing a new annotation instead of using `@frozen`
 
-An initial pitch proposed an new annotation instead of using `@frozen. The
+An initial pitch proposed a new annotation instead of using `@frozen`. The
 problem with that approach was coming up with a reasonable behavior of how the
 new annotation works in resilient modules and what the difference to `@frozen`
 is. Feedback during this and previous pitches was that `@frozen` has more

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -139,7 +139,8 @@ non-resilient Swift.
 We propose to introduce a new language feature `ExtensibleEnums` that aligns the
 behaviour of enumerations in both language dialects. This will make **public**
 enumerations in packages a safe default and leave maintainers the choice of
-extending them later on.
+extending them later on. We also propose to enable this new language feature
+by default with the next lagnuage mode.
 
 In modules with the language feature enabled, developers can use the existing
 `@frozen` attribute to mark an enumeration as non-extensible, allowing consumers
@@ -194,12 +195,12 @@ This proposal only affects API resilience of non-resilient libraries, by enablin
 
 ## Future directions
 
-### Enable `ExtensibleEnums` by default in a future language mode
+### `@unkown case`
 
-We believe that extensible enums should be default in the language to remove the
-common pitfall of using enums in public API and only later on realising that
-those can't be extended in an API compatible way. Since this would be a large
-source breaking change it must be gated behind a new language mode.
+Enums can be used for errors. Catching and pattern matching enums could add
+support for an `@unknown catch` to make pattern matching of typed throws align
+with `switch` pattern matching.
+
 
 ## Alternatives considered
 

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -5,9 +5,9 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Bug: [apple/swift#55110](https://github.com/swiftlang/swift/issues/55110)
-* Implementation: [apple/swift#NNNNN](https://github.com/apple/swift/pull/NNNNN)
+* Implementation: [apple/swift#79580](https://github.com/swiftlang/swift/pull/79580)
 * Upcoming Feature Flag: `ExtensibleEnums`
-* Review: ([pitch](https://forums.swift.org/...))
+* Review: ([pitch](https://forums.swift.org/t/pitch-extensible-enums-for-non-resilient-modules/77649))
 
 Previously pitched in:
 - https://forums.swift.org/t/extensible-enumerations-for-non-resilient-libraries/35900

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -13,14 +13,9 @@ Previously pitched in:
 - https://forums.swift.org/t/extensible-enumerations-for-non-resilient-libraries/35900
 - https://forums.swift.org/t/pitch-non-frozen-enumerations/68373
 
-> **Differences to previous proposals**
-
-> This proposal expands on the previous proposals and incorporates the language
-> steering groups feedback of exploring language features to solve the
-> motivating problem. It also reuses the existing `@frozen` and documents a
-> migration path for existing modules.
-
 Revisions:
+- Re-focused this proposal on introducing a new `@extensible` attribute and
+  moved the language feature to a future direction
 - Introduced a second annotation `@nonExtensible` to allow a migration path into
   both directions
 - Added future directions for adding additional associated values
@@ -36,9 +31,9 @@ Revisions:
 
 ## Introduction
 
-This proposal addresses the long standing behavioral difference of `enum`s in
-Swift modules compiled with and without library evolution. This makes Swift
-`enum`s vastly more useful in public API of non-resilient Swift libraries.
+This proposal provides developers the capabilities to mark public enums in
+non-resilient Swift libraries as extensible. This makes Swift `enum`s vastly
+more useful in public API of such libraries.
 
 ## Motivation
 
@@ -161,28 +156,15 @@ non-resilient Swift.
 
 ## Proposed solution
 
-With the following proposed solution we want to achieve the following goals:
-1. Align the differences between the two language dialects in a future language
-   mode
-2. Provide developers a path to opt-in to the new behavior before the new
-   language mode so they can start declaring **new** extensible enumerations
-3. Provide a migration path to the new behavior without forcing new SemVer
-   majors
-4. Provide tools for developers to treat dependencies as source stable
+We propose to introduce a new `@extensible` attribute that can be applied to
+enumerations to mark them as extensible. Such enums will behave the same way as
+non-frozen enums from resilient Swift libraries.
 
-We propose to introduce a new language feature `ExtensibleEnums` that aligns the
-behavior of enumerations in both language dialects. This will make **public**
-enumerations in packages a safe default and leave maintainers the choice of
-extending them later on. This language feature will become enabled by default in
-the next language mode.
-
-Modules consuming other modules with the language feature enabled will be
-required to add an `@unknown default:`.
-
-An example of using the language feature and the keywords is below:
+An example of using the new attribute is below:
 
 ```swift
 /// Module A
+@extensible
 public enum PizzaFlavor {
     case hawaiian
     case pepperoni
@@ -190,7 +172,7 @@ public enum PizzaFlavor {
 }
 
 /// Module B
-switch pizzaFlavor {  // error: Switch covers known cases, but 'MyEnum' may have additional unknown values, possibly added in future versions
+switch pizzaFlavor { // error: Switch covers known cases, but 'MyEnum' may have additional unknown values, possibly added in future versions
 case .hawaiian:
     throw BadFlavorError()
 case .pepperoni:
@@ -201,186 +183,51 @@ case .cheese:
 }
 ```
 
-Additionally, we propose to re-use the existing `@frozen` annotation to allow
-developers to mark enumerations as non-extensible in non-resilient modules
-similar to how it works in resilient modules already.
+### Exhaustive switching inside same module/package
 
-```swift
-/// Module A
-@frozen
-public enum PizzaFlavor {
-    case hawaiian
-    case pepperoni
-    case cheese
-}
+Code inside the same module or package can be thought of as one co-developed
+unit of code. Switching over an `@extensible` enum inside the same module or
+package will require exhaustive matching to avoid unnecessary `@unknown default`
+cases.
 
-/// Module B
-// The below doesn't require an `@unknown default` since PizzaFlavor is marked as frozen
-switch pizzaFlavor {
-case .hawaiian:
-    throw BadFlavorError()
-case .pepperoni:
-    try validateNoVegetariansEating()
-    return .delicious
-case .cheese:
-    return .delicious
-}
-```
+### `@extensible` and `@frozen`
 
-Turning on the new language feature will be a semantically breaking change for
-consumers of their module; hence, requiring a new SemVer major release of the
-containing package. Some packages can release a new major and adopt the new
-language feature right away; however, the ecosystem also contains packages that
-try to avoid breaking API if at all possible. Such packages are often at the
-very bottom of the dependency graph e.g. `swift-collections` or `swift-nio`. If
-any of such packages releases a new major version it would effectively split the
-ecosystem until all packages have adopted the new major. 
-
-Packages that want to avoid breaking their API can use the new language feature
-and the `@frozen` attribute in combination to unlock to possibility to declare
-**new extensible** public enumerations but stay committed to the non-extensible
-API of the already existing public enumerations. This is achieved by marking all
-existing public enumerations with `@frozen` before turning on the language
-feature.
-
-### Implications on code in the same package
-
-Code inside the same package still needs to exhaustively switch over
-enumerations defined in the same package when the language feature is enabled.
-Switches over enums of the same package containing an `@unknown default` will
-produce a compiler warning.
+An enum cannot be `@frozen` and `@extensible` at the same time. Thus, marking an
+enum both `@extensible` and `@frozen` is not allowed and will result in a
+compiler error.
 
 ### API breaking checker
 
 The behavior of `swift package diagnose-api-breaking-changes` is also updated
-to understand if the language feature is enabled and only diagnose new enum
-cases as a breaking change in non-frozen enumerations.
-
-### Migration paths
-
-The following section is outlining the migration paths and tools we propose to
-provide for different kinds of projects to adopt the proposed feature. The goal
-is to reduce churn across the ecosystem while still allowing us to align the
-default behavior of enums. There are many scenarios why these migration paths
-must exist such as:
-
-- Projects split up into multiple packages
-- Projects build with other tools than Swift PM
-- Projects explicitly vendoring packages without wanting to modify the original
-  source
-- Projects that prefer to deal with source breaks as they come up rather than
-  writing source-stable code
-
-#### Semantically versioned packages
-
-Semantically versioned packages are the primary reason for this proposal. The
-expected migration path for packages when adopting the proposed feature is one
-of the two:
-
-- API stable adoption by turning on the feature and marking all existing public
-  enums with `@frozen`
-- API breaking adoption by turning on the feature and tagging a new major if the
-  public API contains enums
-
-### Projects with multiple non-semantically versioned packages
-
-A common project setup is splitting the code base into multiple packages that
-are not semantically versioned. This can either be done by using local packages
-or by using _revision locked_ dependencies. The packages in such a setup are
-often considered part of the same logical collection of code and would like to
-follow the same source stability rules as same module or same package code. We
-propose to extend the package manifest to allow overriding the package name
-used by a target.
-
-```swift
-extension SwiftSetting {
-    /// Defines the package name used by the target.
-    ///
-    /// This setting is passed as the `-package-name` flag
-    /// to the compiler. It allows overriding the package name on a
-    /// per target basis. The default package name is the package identity.
-    ///
-    /// - Important: Package names should only be aligned across co-developed and
-    ///  co-released packages.
-    ///
-    /// - Parameters:
-    ///   - name: The package name to use.
-    ///   - condition: A condition that restricts the application of the build
-    /// setting.
-    public static func packageName(_ name: String, _ condition: PackageDescription.BuildSettingCondition? = nil) -> PackageDescription.SwiftSetting
-}
-```
-
-This allows to construct arbitrary package _domains_ across multiple targets
-inside a single package or across multiple packages. When adopting the
-`ExtensibleEnums` feature across multiple packages the new Swift setting can be
-used to continue allowing exhaustive matching.
-
-While this setting allows treating multiple targets as part of the same package.
-This setting should only be used across packages when the packages are
-both co-developed and co-released.
-
-### Other build systems
-
-Swift PM isn't the only system used to create and build Swift projects. Build
-systems and IDEs such as Bazel or Xcode offer support for Swift projects as
-well. When using such tools it is common to split a project into multiple
-targets/modules. Since those targets/modules are by default not considered to be
-part of the package, when adopting the `ExtensibleEnums` feature it would
-require to either add an `@unknown default` when switching over enums defined in
-other targets/modules or marking all public enums as `@frozen`. Similarly, to
-the above to avoid this churn we recommend specifying the `-package-name` flag
-to the compiler for all targets/modules that should be considered as part of the
-same unit.
-
-### Escape hatch
-
-There might still be cases where developers need to consume a module that is
-outside of their control which adopts the `ExtensibleEnums` feature. For such
-cases we propose to introduce a new flag `--assume-source-stable-package` that
-allows assuming modules of a package as source stable. When checking if a switch
-needs to be exhaustive we will check if the code is either in the same module,
-the same package, or if the defining package is assumed to be source stable.
-This flag can be passed multiple times to define a set of assumed-source-stable
-packages. 
-
-```swift
-// a.swift inside Package A
-public enum MyEnum {
-    case foo
-    case bar
-}
-
-// b.swift inside Package B compiled with `--assume-source-stable-package A`
-
-switch myEnum { // No @unknown default case needed
-case .foo:
-    print("foo")
-case .bar:
-    print("bar")
-}
-```
-
-In general, we recommend to avoid using this flag but it provides an important
-escape hatch to the ecosystem.
+to understand the new `@extensible` attribute.
 
 ## Source compatibility
 
-- Enabling the language feature `ExtensibleEnums` in a module compiled without
-resiliency that contains public enumerations is a source breaking change unless
-all existing public enumerations are marked with `@frozen`
-- Disabling the language feature `ExtensibleEnums` in a module compiled without
-resiliency is a source compatible change since it implicitly marks all
-enumerations as `@frozen`
-- Adding a `@frozen` annotation to an existing public enumeration is a source
-  compatible change
+### Resilient modules
+
+- Adding or removing the `@extensible` attribute has no-effect since it is the default in this language dialect.
+
+### Non-resilient modules
+
+- Adding the `@extensible` attribute to a public enumeration is an API breaking change.
+- Removing the `@extensible` attribute from a public enumeration is an API stable change.
 
 ## ABI compatibility
 
-The new language feature dos not affect the ABI, as it is already how modules
-compiled with resiliency behave.
+The new attribute does not affect the ABI of an enum since it is already the
+default in resilient modules.
 
 ## Future directions
+
+### Aligning the language dialects
+
+In a previous iteration of this proposal, we proposed to add a new language
+feature to align the language dialects in a future language mode. The main
+motivation behind this is that the current default of non-extensible enums is a
+common pitfall and results in tremendous amounts of unnoticed API breaks in the
+Swift package ecosystem. We still believe that a future proposal should try
+aligning the language dialects. This proposal is focused on providing a first
+step to allow extensible enums in non-resilient modules.
 
 ### `@unknown case`
 
@@ -405,50 +252,15 @@ package tooling could allow to define larger compilation units to express this.
 Until then developers are encouraged to use `@frozen` attributes on their
 enumerations to achieve the same effect.
 
-### Swift PM allowing multiple conflicting major versions in a single dependency graph
-
-To reduce the impact of an API break on the larger ecosystem Swift PM could
-allow multiple conflicting major versions of the same dependency in a single
-dependency graph. This would allow a package to adopt the new language feature,
-break their existing, and release a new major while having minimal impact on
-the larger ecosystem.
-
-### Using `--assume-source-stable-packages` for other diagnostics
-
-During the pitch it was brought up that there are more potential future
-use-cases for assuming modules of another package as source stable such as
-borrowing from a declaration which distinguishes between a stored property and
-one written with a `get`. Such features would also benefit from the
-`--assume-source-stable-packages` flag.
-
 ## Alternatives considered
-
-### Provide an `@extensible` annotation
-
-We believe that the default behavior in both language dialects should be that
-public enumerations are extensible. One of Swift's goals, is safe defaults and
-the current non-extensible default in non-resilient modules doesn't achieve that
-goal. That's why we propose a new language feature to change the default in a
-future Swift language mode.
-
-### Introducing a new annotation instead of using `@frozen`
-
-An initial pitch proposed a new annotation instead of using `@frozen`. The
-problem with that approach was coming up with a reasonable behavior of how the
-new annotation works in resilient modules and what the difference to `@frozen`
-is. Feedback during this and previous pitches was that `@frozen` has more
-implications than just the non-extensibility of enumerations but also impact on
-ABI. We understand the feedback but still believe it is better to re-use the
-same annotation and clearly document the additional behavior when used in
-resilient modules.
 
 ### Introduce a `@preEnumExtensibility` annotation
 
 We considered introducing an annotation that allows developers to mark
-enumerations as pre-existing to the new language feature similar to how
+enumerations as pre-existing to the `@extensible` annotation similar to how
 `@preconcurrency` works. Such an annotation seems to work initially when
 existing public enumerations are marked as `@preEnumExtensibility` instead of
-`@frozen`. It would result in the error about the missing `@unknown default`
+`@extensible`. It would result in the error about the missing `@unknown default`
 case to be downgraded as a warning. However, such an annotation still doesn't
 allow new cases to be added since there is no safe default at runtime when
 encountering an unknown case. Below is an example how such an annotation would
@@ -465,8 +277,8 @@ switch foo {
 case .foo: break
 }
 
-// Package A adopts ExtensibleEnums feature and marks enum as @preEnumExtensibility
-@preEnumExtensibility
+// Package A wants to make the existing enum extensible
+@preEnumExtensibility @extensible
 public enum Foo {
   case foo
 }
@@ -477,7 +289,7 @@ case .foo: break
 }
 
 // Later Package A decides to extend the enum
-@preEnumExtensibility
+@preEnumExtensibility  @extensible
 public enum Foo {
   case foo
   case bar
@@ -487,5 +299,4 @@ public enum Foo {
 switch foo { // error: Unhandled case bar & warning: Enum might be extended later. Add an @unknown default case.
 case .foo: break
 }
-
 ```

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -255,11 +255,15 @@ surfacing a warning about this upcoming break early.
 ### Resilient modules
 
 - Adding or removing the `@extensible` attribute has no-effect since it is the default in this language dialect.
+- Adding the `@preEnumExtensibility` attribute has no-effect since it only downgrades the error to a warning.
+- Removing the `@preEnumExtensibility` attribute is an API breaking since it upgrades the warning to an error again.
 
 ### Non-resilient modules
 
-- Adding the `@extensible` attribute to a public enumeration is an API breaking change.
-- Removing the `@extensible` attribute from a public enumeration is an API stable change.
+- Adding the `@extensible` attribute is an API breaking change.
+- Removing the `@extensible` attribute is an API stable change.
+- Adding the `@preEnumExtensibility` attribute has no-effect since it only downgrades the error to a warning.
+- Removing the `@preEnumExtensibility` attribute is an API breaking since it upgrades the warning to an error again.
 
 ## ABI compatibility
 

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -5,7 +5,7 @@
 * Review Manager: TBD
 * Status: **Awaiting review**
 * Bug: [apple/swift#55110](https://github.com/swiftlang/swift/issues/55110)
-* Implementation: [apple/swift#79580](https://github.com/swiftlang/swift/pull/79580)
+* Implementation: [apple/swift#80503](https://github.com/swiftlang/swift/pull/80503)
 * Upcoming Feature Flag: `ExtensibleEnums`
 * Review: ([pitch](https://forums.swift.org/t/pitch-extensible-enums-for-non-resilient-modules/77649))
 

--- a/proposals/NNNN-extensible-enums.md
+++ b/proposals/NNNN-extensible-enums.md
@@ -176,6 +176,9 @@ Changing the annotation from `@extensible` to `@frozen` is a source compatible
 change and will only result in a warning code that used `@unknown default:`
 clause. This allows developers to commit to the API of an enum in a non-source
 breaking way.
+Adding an `@extensible` annotation is a source breaking change in modules that
+have **not** enabled the `ExtensibleEnums` language features or are compiled
+with resiliency.
 
 ## Effect on ABI stability
 
@@ -193,3 +196,13 @@ We believe that extensible enums should be default in the language to remove the
 common pitfall of using enums in public API and only later on realising that
 those can't be extended in an API compatible way. Since this would be a large
 source breaking change it must be gated behind a new language mode.
+
+## Alternatives considered
+
+### Only provide the `@extensible` annotation
+
+We believe that the default behaviour in both language dialects should be that
+public enumerations are extensible. One of Swift's goals, is safe defaults and
+the current non-extensible default in non-resilient modules doesn't achieve that
+goal. That's why we propose a new language feature to change the default in a
+future Swift language mode.


### PR DESCRIPTION
This adds a pitch for extensible enums in non-resilient Swift modules.