### PR TITLE
[SE-0460] Fix metadata of `@specialized` proposal

### DIFF
--- a/proposals/0460-specialized.md
+++ b/proposals/0460-specialized.md
@@ -5,7 +5,7 @@
 * Review Manager: [Steve Canon](https://github.com/stephentyrone)
 * Status: **Active Review (January 29 ... February 11, 2025)**
 * Implementation: Available in nightly toolchains using the underscored `@_specialize`
-* Discussion: ([pitch](https://forums.swift.org/t/pitch-explicit-specialization/76967))([review](https://forums.swift.org/t/se-0460-explicit-specialization/77541))
+* Review: ([pitch](https://forums.swift.org/t/pitch-explicit-specialization/76967)) ([review](https://forums.swift.org/t/se-0460-explicit-specialization/77541))
 
 ## Introduction
 


### PR DESCRIPTION
The proposal isn't listed on the [dashboard](https://www.swift.org/swift-evolution/) because there's an error message: "Missing Review field."

```sh
curl https://download.swift.org/swift-evolution/v1/evolution.json
```

Cc: @stephentyrone @DougGregor
