### PR TITLE
[SE-0430] Remove borrowing sending example and update ownership rules

### DIFF
--- a/proposals/0430-transferring-parameters-and-results.md
+++ b/proposals/0430-transferring-parameters-and-results.md
@@ -390,17 +390,11 @@ the callee. Unlike `consuming` parameters, `sending` parameters do not
 have no-implicit-copying semantics.
 
 To opt into no-implicit-copying semantics or to change the default ownership
-convention, `sending` may also be paired with an explicit `consuming` or
-`borrowing` ownership modifier:
+convention, `sending` may also be paired with an explicit `consuming` ownership modifier:
 
 ```swift
 func sendingConsuming(_ x: consuming sending T) { ... }
-func sendingBorrowing(_ x: borrowing sending T) { ... }
 ```
-
-Note that an explicit `borrowing` annotation always implies no-implicit-copying,
-so there is no way to change the default ownership convention of a
-`sending` parameter without also opting into no-implicit-copying semantics.
 
 ### Adoption in the Concurrency library
 


### PR DESCRIPTION
The combination of borrowing sending has been partially disallowed, and from a [Swift developer's perspective](https://forums.swift.org/t/accepted-with-modifications-se-0430-second-review-sendable-parameter-and-result-values/71850), it is no longer compilable.
To avoid confusion for readers (including myself! 😊), I believe it would be best to remove references to it from the document.

Please let me know if my suggestion seems off or if there are any additional changes that should be made!