### PR TITLE
[SE-0458] Improvements to strict memory safety checking based on the ongoing review

### DIFF
--- a/proposals/0458-strict-memory-safety.md
+++ b/proposals/0458-strict-memory-safety.md
@@ -470,7 +470,7 @@ The `@unsafe` annotation is at the class level because any use of the `Sub` type
 
 #### `for..in` loops
 
-Swift's `for..in` loops are effectively implemented as syntactic sugar over the `Sequence` and `IteratorProtocol` protocols, where the `for..in` creates a new iterator (with `Sequence.makeIterator()`) and then calls its `next()` operation for each loop iteration. If the conformances to `Sequence` are `IteratorProtocol` is `@unsafe`, the loop will introduce a warning:
+Swift's `for..in` loops are effectively implemented as syntactic sugar over the `Sequence` and `IteratorProtocol` protocols, where the `for..in` creates a new iterator (with `Sequence.makeIterator()`) and then calls its `next()` operation for each loop iteration. If the conformances to `Sequence` or `IteratorProtocol` are `@unsafe`, the loop will introduce a warning:
 
 ```swift
 let someUnsafeBuffer: UnsafeBufferPointer<Element> = unsafe ...
@@ -824,7 +824,7 @@ We could introduce an optional `message` argument to the `@unsafe` attribute, wh
 
 ## Revision history
 
-* **Revision 3 (following second review eextension)**
+* **Revision 3 (following second review extension)**
   * Do not require declarations with unsafe types in their signature to be marked `@unsafe`; it is implied. They may be marked `@safe` to indicate that they are actually safe.
   * Add `unsafe` for iteration via the `for..in` syntax.
   * Add C(++) interoperability section that infers `@unsafe` for C types that involve pointers.

--- a/proposals/0458-strict-memory-safety.md
+++ b/proposals/0458-strict-memory-safety.md
@@ -419,6 +419,30 @@ A type has unsafe storage if:
 * Any stored instance property (for `actor`, `class`, and `struct` types) or associated value (for cases of `enum` types) have a type that involves an unsafe type or conformance.
 * Any stored instance property uses one of the unsafe language features (such as `unowned(unsafe)`).
 
+#### Unsafe witnesses
+
+When a type conforms to a given protocol, it must satisfy all of the requirements of that protocol. Part of this process is determining which declaration (called the *witness*) satisfies a given protocol requirement. If a particular witness is unsafe but the corresponding requirement is not safe, the compiler will produce a warning:
+
+```swift
+protocol P {
+  func f()
+}
+
+struct ConformsToP { }
+
+extension ConformsToP: P {
+  @unsafe func f() { } // warning: unsafe instance method 'f()' cannot satisfy safe requirement
+}
+```
+
+This unsafety can be acknowledged by marking the conformance as `@unsafe`, e.g.,
+
+```swift
+extension ConformsToP: @unsafe P {
+  @unsafe func f() { } // okay, it's an unsafe conformance
+}
+```
+
 #### Unsafe overrides
 
 Overriding a safe method within an `@unsafe` one could introduce unsafety, so it will produce a diagnostic in the strict safety mode:


### PR DESCRIPTION
This pull request improves the proposal in number of ways:

* Do not require declarations with unsafe types in their signature to be marked `@unsafe`; it is implied. They may be marked `@safe` to indicate that they are actually safe.
* Add `unsafe` for iteration via the `for..in` syntax.
* Add C(++) interoperability section that infers `@unsafe` for C types that involve pointers.
* Document the unsafe conformances of the `UnsafeBufferPointer` family of types to the `Collection` protocol hierarchy.
* Restructure detailed design to separate out "sources of unsafety" from "acknowledging unsafety".