### PR TITLE
Mark SE-0453 as accepted

### DIFF
--- a/proposals/0453-vector.md
+++ b/proposals/0453-vector.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0453](0453-vector.md)
 * Authors: [Alejandro Alonso](https://github.com/Azoy)
 * Review Manager: [Freddy Kellison-Linn](https://github.com/Jumhyn)
-* Status: **Active review (December 5...December 17, 2024)**
+* Status: **Accepted**
 * Roadmap: [Approaches for fixed-size arrays](https://forums.swift.org/t/approaches-for-fixed-size-arrays/58894)
 * Implementation: [swiftlang/swift#76438](https://github.com/swiftlang/swift/pull/76438)
 * Review: ([pitch](https://forums.swift.org/t/vector-a-fixed-size-array/75264)) ([review](https://forums.swift.org/t/se-0453-vector-a-fixed-size-array/76004)) ([returned for revision](https://forums.swift.org/t/returned-for-revision-se-0453-vector-a-fixed-size-array/76411)) ([second review](https://forums.swift.org/t/second-review-se-0453-vector-a-fixed-size-array/76412))


### PR DESCRIPTION
SE-0453 was accepted in https://forums.swift.org/t/accepted-with-modifications-se-0453-inlinearray-formerly-vector-a-fixed-size-array/77678 but the proposal wasn’t updated.