### PR TITLE
Mark SE-0443 as implemented in Swift 6.1.

### DIFF
--- a/proposals/0443-warning-control-flags.md
+++ b/proposals/0443-warning-control-flags.md
@@ -4,7 +4,7 @@
 * Proposal: [SE-0443](0443-warning-control-flags.md)
 * Authors: [Doug Gregor](https://github.com/douggregor), [Dmitrii Galimzianov](https://github.com/DmT021)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.1)**
 * Implementation: [apple/swift#74466](https://github.com/swiftlang/swift/pull/74466)
 * Review: ([pitch](https://forums.swift.org/t/warnings-as-errors-exceptions/72925)) ([review](https://forums.swift.org/t/se-0443-precise-control-flags-over-compiler-warnings/74116)) ([acceptance](https://forums.swift.org/t/accepted-se-0443-precise-control-flags-over-compiler-warnings/74377))
 * Previous revisions: [1](https://github.com/swiftlang/swift-evolution/blob/57fe29d5d55edb85b14c153b7f4cbead6b6539eb/proposals/0443-warning-control-flags.md), [2](https://github.com/swiftlang/swift-evolution/blob/7b12899ad0d96002c793d33ef8109ec47c5d256f/proposals/0443-warning-control-flags.md)


### PR DESCRIPTION
It looks like the implementation PR is in the Swift 6.1 snapshots, assuming there's nothing else outstanding.