### PR TITLE
[SE-0461] Fix not correct syntax in a function call

### DIFF
--- a/proposals/0461-async-function-isolation.md
+++ b/proposals/0461-async-function-isolation.md
@@ -327,8 +327,6 @@ The type of an `@execution(caller)` function declaration is an
 ```swift
 class NotSendable { ... }
 
-func useAsValue(_ ns: NotSendable) async { ... }
-
 @MainActor let global: NotSendable = .init()
 
 @execution(caller)
@@ -344,7 +342,7 @@ func callSendableClosure() async {
   await closure(global) // okay
 }
 
-callSendableClosure(useAsValue)
+callSendableClosure()
 ```
 
 In the above code, the calls to `closure` from `callSendableClosure` run on the


### PR DESCRIPTION
The code shows that there appears to be a mismatch in the function calls. While `callSendableClosure` is called  with `useAsValue`, it is defined without any arguments.