### PR TITLE
[SE-0463] Fix sendable-completion-handlers status

### DIFF
--- a/proposals/0463-sendable-completion-handlers.md
+++ b/proposals/0463-sendable-completion-handlers.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0463](0463-sendable-completion-handlers.md)
 * Authors: [Holly Borla](https://github.com/hborla)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Active Review (Feburary 27th...March 10th, 2025)**
+* Status: **Active Review (February 27th...March 10th, 2025)**
 * Vision: [Improving the approachability of data-race safety](https://github.com/swiftlang/swift-evolution/blob/main/visions/approachable-concurrency.md)
 * Implementation: On `main` behind `-enable-experimental-feature SendableCompletionHandlers`
 * Review: ([pitch](https://forums.swift.org/t/pitch-import-objective-c-completion-handler-parameters-as-sendable/77904)) ([review](https://forums.swift.org/t/se-0463-import-objective-c-completion-handler-parameters-as-sendable/78169))


### PR DESCRIPTION
"Feburary" is ignored, so the dashboard data contains a 12-month review.

```
      "status" : {
        "end" : "2026-03-10T00:00:00Z",
        "start" : "2025-03-27T00:00:00Z",
        "state" : "activeReview"
      },
```

Cc: @rjmccall
