### PR TITLE
Update the Swift evolution process documentation to incorporate Swift Testing

### DIFF
--- a/process.md
+++ b/process.md
@@ -5,10 +5,15 @@ Swift is a powerful and intuitive programming language that is designed to make 
 ## Scope
 
 The Swift evolution process covers all design changes, no matter how small, to the Swift language, its standard library, and the core tools necessary to build Swift programs.  This includes additions, removals, and changes to:
+
 - the features of the Swift language,
 - the public interface of the Swift standard library,
-- the configuration of the Swift compiler, and
-- the core tools of the Swift package ecosystem, including the configuration of the [Swift package manager](https://www.swift.org/package-manager/) and the design of its manifest files.
+- the configuration of the Swift compiler,
+- the core tools of the Swift package ecosystem, including the configuration of
+  the [Swift package manager](https://www.swift.org/package-manager/) and the
+  design of its manifest files, and
+- the features and public interfaces of
+  [Swift Testing](https://github.com/swiftlang/swift-testing).
 
 The design of other tools, such as IDEs, debuggers, and documentation generators, is not covered by the evolution process.  The Core Team may create workgroups to guide and make recommendations about the development of these tools, but the output of those workgroups is not reviewed.
 
@@ -31,9 +36,11 @@ There is a natural tension between these two goals. Open evolution processes are
 
 The [Core Team](https://www.swift.org/community/#core-team) is responsible for the strategic direction of Swift.  The Core Team creates workgroups focused on specific parts of the project.  When the Core Team gives a workgroup authority over part of the evolution of the project, that workgroup is called an evolution workgroup.  Evolution workgroups manage the evolution process for proposals under their authority, working together with other workgroups as needed.
 
-Currently, there is only one evolution workgroup:
+Currently, there are two evolution workgroups:
 
 * The [Language Steering Group][language-steering-group] has authority over the evolution of the Swift language and its standard library.
+* The [Testing Workgroup][testing-workgroup] has authority over the evolution of
+  the Swift Testing and Corelibs XCTest projects.
 
 The Core Team manages (or delegates) the evolution process for proposals outside these areas.  The Core Team also retains the power to override the evolution decisions of workgroups when necessary.
 
@@ -93,8 +100,11 @@ Please state explicitly whether you believe that the proposal should be accepted
 
 1. **Develop the proposal and implementation**
 
-   1. Expand the rough sketch into a formal proposal using the [proposal template](proposal-templates/0000-swift-template.md).
-   1. In the [swift-evolution repository][swift-evolution-repo], open a [draft pull request][draft-pr] that adds your proposal to the [proposals directory](/proposals).
+   1. Expand the rough sketch into a formal proposal using the
+      [relevant proposal template](#proposal-templates).
+   1. In the [swift-evolution repository][swift-evolution-repo], open a
+      [draft pull request][draft-pr] that adds your proposal to the appropriate
+      [proposal directory](#proposal-locations).
    1. Announce the pull request on the forums and edit the root post to link out to the pull request.
    1. Refine the formal proposal in the open as you receive further feedback on the forums or the pull request.
       A ripe proposal is expected to address commentary from present and past
@@ -127,6 +137,28 @@ Please state explicitly whether you believe that the proposal should be accepted
 > In general, and especially [during the review period](#review-process), be responsive to questions and feedback about the proposal.
 
 [draft-pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests
+
+### Proposal templates
+
+When writing a formal proposal document, start with the most relevant template
+given the primary subject of the proposal:
+
+- Use the [Swift template][swift-template] for proposals concerning the Swift
+  language, compiler, or standard library.
+- Use the [Swift Package Manager template][swiftpm-template] for proposals
+  related to SwiftPM, including the design of its package manifest files and
+  command-line tools.
+- Use the [Swift Testing template][swift-testing-template] for proposals focused
+  on Swift Testing features or public interfaces.
+
+### Proposal locations
+
+When opening a pull request to add a new proposal to the
+[swift-evolution repository][swift-evolution-repo], place proposals which use
+the [Swift][swift-template] or [Swift Package Manager][swiftpm-template]
+templates in the top-level [proposals](/proposals) directory. Place proposals
+which use the newer [Swift Testing template][swift-testing-template] in the
+[proposals/testing](/proposals/testing) subdirectory.
 
 ## Review process
 
@@ -211,6 +243,10 @@ A given proposal can be in one of several states:
 [status-page]: https://apple.github.io/swift-evolution/
 [preview-package]: https://github.com/apple/swift-standard-library-preview/
 [language-steering-group]: https://www.swift.org/language-steering-group
+[testing-workgroup]: https://www.swift.org/testing-workgroup  "Testing Workgroup page on Swift.org"
+[swift-template]: proposal-templates/0000-swift-template.md  "Swift proposal template"
+[swiftpm-template]: proposal-templates/0000-swiftpm-template.md  "Swift Package Manager proposal template"
+[swift-testing-template]: proposal-templates/0000-swift-testing-template.md  "Swift Testing proposal template"
 
 ## Review announcement
 

--- a/process.md
+++ b/process.md
@@ -36,9 +36,10 @@ There is a natural tension between these two goals. Open evolution processes are
 
 The [Core Team](https://www.swift.org/community/#core-team) is responsible for the strategic direction of Swift.  The Core Team creates workgroups focused on specific parts of the project.  When the Core Team gives a workgroup authority over part of the evolution of the project, that workgroup is called an evolution workgroup.  Evolution workgroups manage the evolution process for proposals under their authority, working together with other workgroups as needed.
 
-Currently, there are two evolution workgroups:
+Currently, there are three evolution workgroups:
 
-* The [Language Steering Group][language-steering-group] has authority over the evolution of the Swift language and its standard library.
+* The [Language Steering Group][language-steering-group] has authority over the evolution of the Swift language, its standard library, and any language configuration features of the Swift package manager.
+* The [Platform Steering Group][platform-steering-group] has authority over the evolution of all other features of the Swift package manager and its manifest files.
 * The [Testing Workgroup][testing-workgroup] has authority over the evolution of
   the Swift Testing and Corelibs XCTest projects.
 
@@ -243,6 +244,7 @@ A given proposal can be in one of several states:
 [status-page]: https://apple.github.io/swift-evolution/
 [preview-package]: https://github.com/apple/swift-standard-library-preview/
 [language-steering-group]: https://www.swift.org/language-steering-group
+[platform-steering-group]: https://www.swift.org/platform-steering-group
 [testing-workgroup]: https://www.swift.org/testing-workgroup  "Testing Workgroup page on Swift.org"
 [swift-template]: proposal-templates/0000-swift-template.md  "Swift proposal template"
 [swiftpm-template]: proposal-templates/0000-swiftpm-template.md  "Swift Package Manager proposal template"

--- a/process.md
+++ b/process.md
@@ -12,8 +12,9 @@ The Swift evolution process covers all design changes, no matter how small, to t
 - the core tools of the Swift package ecosystem, including the configuration of
   the [Swift package manager](https://www.swift.org/package-manager/) and the
   design of its manifest files, and
-- the features and public interfaces of
-  [Swift Testing](https://github.com/swiftlang/swift-testing).
+- the public interfaces of the following libraries:
+  - [Swift Testing](https://github.com/swiftlang/swift-testing)
+  - [XCTest](https://github.com/swiftlang/swift-corelibs-xctest)
 
 The design of other tools, such as IDEs, debuggers, and documentation generators, is not covered by the evolution process.  The Core Team may create workgroups to guide and make recommendations about the development of these tools, but the output of those workgroups is not reviewed.
 


### PR DESCRIPTION
This includes a handful of updates and edits to `process.md` which documents the Swift evolution process so that it mentions [Swift Testing](https://github.com/swiftlang/swift-testing), the [Testing Workgroup](https://github.com/swiftlang/swift-org-website/pull/920), and the [newly-added](#2709) Swift Testing [template](https://github.com/swiftlang/swift-evolution/blob/main/proposal-templates/0000-swift-testing-template.md) file.