### PR TITLE
Replace two outdated links in 'process.md'

### DIFF
--- a/process.md
+++ b/process.md
@@ -111,7 +111,7 @@ Please state explicitly whether you believe that the proposal should be accepted
       Proposals that can ship as part of the [Standard Library Preview package][preview-package]
       should be paired with a pull request against the [swift-evolution-staging repository][swift-evolution-staging].
       All other proposals should be paired with an implementation pull request
-      against the [main Swift repository](https://github.com/apple/swift).
+      against the [main Swift repository](https://github.com/swiftlang/swift).
 
       The preview package can accept new types, new protocols, and extensions to
       existing types and protocols that can be implemented without access to
@@ -208,7 +208,7 @@ A given proposal can be in one of several states:
 [swift-evolution-repo]: https://github.com/swiftlang/swift-evolution  "Swift evolution repository"
 [swift-evolution-staging]: https://github.com/swiftlang/swift-evolution-staging  "Swift evolution staging repository"
 [proposal-reviews]: https://forums.swift.org/c/evolution/proposal-reviews "'Proposal reviews' category of the Swift forums"
-[status-page]: https://apple.github.io/swift-evolution/
+[status-page]: https://www.swift.org/swift-evolution
 [preview-package]: https://github.com/apple/swift-standard-library-preview/
 [language-steering-group]: https://www.swift.org/language-steering-group
 


### PR DESCRIPTION
This is a small PR to replace two links in `process.md` which still reference the Apple GitHub organization instead of swiftlang. (I noticed these while working on #2729 but they were out of scope for that PR.) The existing links aren't broken, they do redirect successfully, but it's nicer to use the correct URLs.