### PR TITLE
Mark metatype keypaths and swift language mode proposals as implemented

### DIFF
--- a/proposals/0438-metatype-keypath.md
+++ b/proposals/0438-metatype-keypath.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0438](0438-metatype-keypath.md)
 * Authors: [Amritpan Kaur](https://github.com/amritpan), [Pavel Yaskevich](https://github.com/xedin)
 * Review Manager: [Joe Groff](https://github.com/jckarter)
-* Status: **Accepted** 
+* Status: **Implemented (Swift 6.1)**
 * Implementation: [apple/swift#73242](https://github.com/apple/swift/pull/73242)
 * Review: ([pitch](https://forums.swift.org/t/pitch-metatype-keypaths/70767)) ([review](https://forums.swift.org/t/se-0438-metatype-keypaths/72172)) ([acceptance](https://forums.swift.org/t/accepted-se-0438-metatype-keypaths/72878))
 

--- a/proposals/0441-formalize-language-mode-terminology.md
+++ b/proposals/0441-formalize-language-mode-terminology.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0441](0441-formalize-language-mode-terminology.md)
 * Author: [James Dempsey](https://github.com/dempseyatgithub)
 * Review Manager: [John McCall](https://github.com/rjmccall)
-* Status: **Accepted** 
+* Status: **Implemented (Swift 6.1)**
 * Implementation: [swiftlang/swift-package-manager#7620](https://github.com/swiftlang/swift-package-manager/pull/7620), [swiftlang/swift#75564](https://github.com/swiftlang/swift/pull/75564)
 * Review: ([first pitch](https://forums.swift.org/t/pitch-formalize-swift-language-mode-naming-in-tools-and-api/71733)) ([second pitch](https://forums.swift.org/t/pitch-2-formalize-language-mode-naming-in-tools-and-api/72136)) ([review](https://forums.swift.org/t/se-0441-formalize-language-mode-terminology/73182)) ([acceptance](https://forums.swift.org/t/accepted-se-0441-formalize-language-mode-terminology/73716))
 


### PR DESCRIPTION
SE-0438 and SE-0441 respectively are implemented in 6.1 compiler.