### PR TITLE
[SE-0317] fix minor typo

### DIFF
--- a/proposals/0317-async-let.md
+++ b/proposals/0317-async-let.md
@@ -148,7 +148,7 @@ func asynchronous() async {
 and inside asynchronous closures:
 
 ```swift
-func callMe(_ maybe: () async -> String) async -> String 
+func callMe(_ maybe: () async -> String) async -> String {
   return await maybe()
 }
 


### PR DESCRIPTION
In the structured concurrency documentation, there is a snippet:
`func callMe(_ maybe: () async -> String) async -> String return await maybe }`

It appears the opening brace { is missing after this function signature. Currently, the code snippet ends right after the signature, which makes it syntactically incorrect. We should add the { (and corresponding }) to properly define the function body. For example:
`func callMe(_ maybe: () async -> String) async -> String {
    return await maybe()
}`