### PR TITLE
Change state of ST-0010 to Implemented

### DIFF
--- a/proposals/testing/0010-evaluate-condition.md
+++ b/proposals/testing/0010-evaluate-condition.md
@@ -3,7 +3,7 @@
 * Proposal: [ST-0010](0010-evaluate-condition.md)
 * Authors: [David Catmull](https://github.com/Uncommon)
 * Review Manager: [Stuart Montgomery](https://github.com/stmontgomery)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.2)**
 * Bug: [swiftlang/swift-testing#903](https://github.com/swiftlang/swift-testing/issues/903)
 * Implementation: [swiftlang/swift-testing#909](https://github.com/swiftlang/swift-testing/pull/909)
 * Review: ([pitch](https://forums.swift.org/t/pitch-introduce-conditiontrait-evaluate/77242)), ([review](https://forums.swift.org/t/st-0010-public-api-to-evaluate-conditiontrait/79232)), ([acceptance](https://forums.swift.org/t/accepted-st-0010-public-api-to-evaluate-conditiontrait/79577))

--- a/proposals/testing/0010-evaluate-condition.md
+++ b/proposals/testing/0010-evaluate-condition.md
@@ -5,7 +5,7 @@
 * Review Manager: [Stuart Montgomery](https://github.com/stmontgomery)
 * Status: **Implemented (Swift 6.2)**
 * Bug: [swiftlang/swift-testing#903](https://github.com/swiftlang/swift-testing/issues/903)
-* Implementation: [swiftlang/swift-testing#909](https://github.com/swiftlang/swift-testing/pull/909)
+* Implementation: [swiftlang/swift-testing#909](https://github.com/swiftlang/swift-testing/pull/909), [swiftlang/swift-testing#1097](https://github.com/swiftlang/swift-testing/pull/1097)
 * Review: ([pitch](https://forums.swift.org/t/pitch-introduce-conditiontrait-evaluate/77242)), ([review](https://forums.swift.org/t/st-0010-public-api-to-evaluate-conditiontrait/79232)), ([acceptance](https://forums.swift.org/t/accepted-st-0010-public-api-to-evaluate-conditiontrait/79577))
 
 ## Introduction


### PR DESCRIPTION
[ST-0010: Public API to evaluate ConditionTrait](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0010-evaluate-condition.md) has been fully implemented in Swift 6.2 now.

The final code change happened in https://github.com/swiftlang/swift-testing/pull/1097, which was subsequently merged to 6.2 in https://github.com/swiftlang/swift-testing/pull/1101.