### PR TITLE
Consistently format the 'Review:' header field of all Swift Testing proposals

### DIFF
--- a/proposals/testing/0001-refactor-bug-inits.md
+++ b/proposals/testing/0001-refactor-bug-inits.md
@@ -4,7 +4,7 @@
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
 * Status: **Implemented (Swift 6.0)**
 * Implementation: [swiftlang/swift-testing#401](https://github.com/swiftlang/swift-testing/pull/401)
-* Review: ([pitch](https://forums.swift.org/t/pitch-dedicated-bug-functions-for-urls-and-ids/71842)), ([acceptance](https://forums.swift.org/t/swt-0001-dedicated-bug-functions-for-urls-and-ids/71842/2))
+* Review: ([pitch](https://forums.swift.org/t/pitch-dedicated-bug-functions-for-urls-and-ids/71842)) ([acceptance](https://forums.swift.org/t/swt-0001-dedicated-bug-functions-for-urls-and-ids/71842/2))
 
 > [!NOTE]
 > This proposal was accepted before Swift Testing began using the Swift

--- a/proposals/testing/0002-json-abi.md
+++ b/proposals/testing/0002-json-abi.md
@@ -5,7 +5,7 @@
 * Status: **Implemented (Swift 6.0)**
 * Implementation: [swiftlang/swift-testing#383](https://github.com/swiftlang/swift-testing/pull/383),
   [swiftlang/swift-testing#402](https://github.com/swiftlang/swift-testing/pull/402)
-* Review: ([pitch](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627)), ([acceptance](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627/4))
+* Review: ([pitch](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627)) ([acceptance](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627/4))
 
 > [!NOTE]
 > This proposal was accepted before Swift Testing began using the Swift

--- a/proposals/testing/0003-make-serialized-trait-api.md
+++ b/proposals/testing/0003-make-serialized-trait-api.md
@@ -5,9 +5,7 @@
 * Status: **Implemented (Swift 6.0)**
 * Implementation: 
 [swiftlang/swift-testing#535](https://github.com/swiftlang/swift-testing/pull/535)
-* Review: 
-([pitch](https://forums.swift.org/t/pitch-make-serialized-trait-public-api/73147)),
-([acceptance](https://forums.swift.org/t/pitch-make-serialized-trait-public-api/73147/5))
+* Review: ([pitch](https://forums.swift.org/t/pitch-make-serialized-trait-public-api/73147)) ([acceptance](https://forums.swift.org/t/pitch-make-serialized-trait-public-api/73147/5))
 
 > [!NOTE]
 > This proposal was accepted before Swift Testing began using the Swift

--- a/proposals/testing/0004-constrain-the-granularity-of-test-time-limit-durations.md
+++ b/proposals/testing/0004-constrain-the-granularity-of-test-time-limit-durations.md
@@ -5,9 +5,7 @@
 * Status: **Implemented (Swift 6.0)**
 * Implementation: 
 [swiftlang/swift-testing#534](https://github.com/swiftlang/swift-testing/pull/534)
-* Review: 
-([pitch](https://forums.swift.org/t/pitch-constrain-the-granularity-of-test-time-limit-durations/73146)),
-([acceptance](https://forums.swift.org/t/pitch-constrain-the-granularity-of-test-time-limit-durations/73146/3))
+* Review: ([pitch](https://forums.swift.org/t/pitch-constrain-the-granularity-of-test-time-limit-durations/73146)) ([acceptance](https://forums.swift.org/t/pitch-constrain-the-granularity-of-test-time-limit-durations/73146/3))
 
 > [!NOTE]
 > This proposal was accepted before Swift Testing began using the Swift

--- a/proposals/testing/0005-ranged-confirmations.md
+++ b/proposals/testing/0005-ranged-confirmations.md
@@ -5,8 +5,7 @@
 * Status: **Implemented (Swift 6.1)**
 * Bug: rdar://138499457
 * Implementation: [swiftlang/swift-testing#598](https://github.com/swiftlang/swift-testing/pull/598), [swiftlang/swift-testing#689](https://github.com/swiftlang/swift-testing/pull689)
-* Review: ([pitch](https://forums.swift.org/t/pitch-range-based-confirmations/74589)),
-  ([acceptance](https://forums.swift.org/t/pitch-range-based-confirmations/74589/7))
+* Review: ([pitch](https://forums.swift.org/t/pitch-range-based-confirmations/74589)) ([acceptance](https://forums.swift.org/t/pitch-range-based-confirmations/74589/7))
 
 > [!NOTE]
 > This proposal was accepted before Swift Testing began using the Swift

--- a/proposals/testing/0006-return-errors-from-expect-throws.md
+++ b/proposals/testing/0006-return-errors-from-expect-throws.md
@@ -5,7 +5,7 @@
 * Status: **Implemented (Swift 6.1)**
 * Bug: rdar://138235250
 * Implementation: [swiftlang/swift-testing#780](https://github.com/swiftlang/swift-testing/pull/780)
-* Review: ([pitch](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567)), ([acceptance](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567/5))
+* Review: ([pitch](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567)) ([acceptance](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567/5))
 
 > [!NOTE]
 > This proposal was accepted before Swift Testing began using the Swift

--- a/proposals/testing/0007-test-scoping-traits.md
+++ b/proposals/testing/0007-test-scoping-traits.md
@@ -4,7 +4,7 @@
 * Authors: [Stuart Montgomery](https://github.com/stmontgomery)
 * Status: **Implemented (Swift 6.1)**
 * Implementation: [swiftlang/swift-testing#733](https://github.com/swiftlang/swift-testing/pull/733), [swiftlang/swift-testing#86](https://github.com/swiftlang/swift-testing/pull/86)
-* Review: ([pitch](https://forums.swift.org/t/pitch-custom-test-execution-traits/75055)), ([review](https://forums.swift.org/t/proposal-test-scoping-traits/76676)), ([acceptance](https://forums.swift.org/t/proposal-test-scoping-traits/76676/3))
+* Review: ([pitch](https://forums.swift.org/t/pitch-custom-test-execution-traits/75055)) ([review](https://forums.swift.org/t/proposal-test-scoping-traits/76676)) ([acceptance](https://forums.swift.org/t/proposal-test-scoping-traits/76676/3))
 
 > [!NOTE]
 > This proposal was accepted before Swift Testing began using the Swift

--- a/proposals/testing/0008-exit-tests.md
+++ b/proposals/testing/0008-exit-tests.md
@@ -7,7 +7,7 @@
 * Bug: [apple/swift-testing#157](https://github.com/apple/swift-testing/issues/157)
 * Implementation: [apple/swift-testing#324](https://github.com/swiftlang/swift-testing/pull/324)
 * Previous Revision: [1](https://github.com/swiftlang/swift-evolution/blob/fdfc7867df4e35e29b2a24edee34ea4412ec15b0/proposals/testing/0008-exit-tests.md)
-* Review: ([acceptance](https://forums.swift.org/t/accepted-with-modifications-st-0008-exit-tests/79553)) ([second review](https://forums.swift.org/t/second-review-st-0008-exit-tests/79198)), ([review](https://forums.swift.org/t/st-0008-exit-tests/78692)), ([pitch](https://forums.swift.org/t/pitch-exit-tests/78071))
+* Review: ([pitch](https://forums.swift.org/t/pitch-exit-tests/78071)) ([review](https://forums.swift.org/t/st-0008-exit-tests/78692)) ([second review](https://forums.swift.org/t/second-review-st-0008-exit-tests/79198)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-st-0008-exit-tests/79553))
 
 ## Introduction
 

--- a/proposals/testing/0009-attachments.md
+++ b/proposals/testing/0009-attachments.md
@@ -6,7 +6,7 @@
 * Status: **Implemented (Swift 6.2)**
 * Bug: [swiftlang/swift-testing#714](https://github.com/swiftlang/swift-testing/issues/714)
 * Implementation: [swiftlang/swift-testing#973](https://github.com/swiftlang/swift-testing/pull/973)
-* Review: ([acceptance](https://forums.swift.org/t/accepted-with-modifications-st-0009-attachments/79193)), ([review](https://forums.swift.org/t/st-0009-attachments/78698)), ([pitch](https://forums.swift.org/t/pitch-attachments/78072))
+* Review: ([pitch](https://forums.swift.org/t/pitch-attachments/78072)) ([review](https://forums.swift.org/t/st-0009-attachments/78698)) ([acceptance](https://forums.swift.org/t/accepted-with-modifications-st-0009-attachments/79193))
 
 ## Introduction
 

--- a/proposals/testing/0010-evaluate-condition.md
+++ b/proposals/testing/0010-evaluate-condition.md
@@ -6,7 +6,7 @@
 * Status: **Implemented (Swift 6.2)**
 * Bug: [swiftlang/swift-testing#903](https://github.com/swiftlang/swift-testing/issues/903)
 * Implementation: [swiftlang/swift-testing#909](https://github.com/swiftlang/swift-testing/pull/909), [swiftlang/swift-testing#1097](https://github.com/swiftlang/swift-testing/pull/1097)
-* Review: ([pitch](https://forums.swift.org/t/pitch-introduce-conditiontrait-evaluate/77242)), ([review](https://forums.swift.org/t/st-0010-public-api-to-evaluate-conditiontrait/79232)), ([acceptance](https://forums.swift.org/t/accepted-st-0010-public-api-to-evaluate-conditiontrait/79577))
+* Review: ([pitch](https://forums.swift.org/t/pitch-introduce-conditiontrait-evaluate/77242)) ([review](https://forums.swift.org/t/st-0010-public-api-to-evaluate-conditiontrait/79232)) ([acceptance](https://forums.swift.org/t/accepted-st-0010-public-api-to-evaluate-conditiontrait/79577))
 
 ## Introduction
 


### PR DESCRIPTION
This contains minor, formatting consistency fixes to the `Review:` header field of all Swift Testing proposals in the `proposals/testing/` subdirectory. The entries in this header field should be:

- ordered oldest-to-newest,
- lowercased,
- enclosed in parentheses,
- separated by a single space character, and
- on a single line.
