### PR TITLE
typo: ends -> begins

### DIFF
--- a/proposals/0433-mutex.md
+++ b/proposals/0433-mutex.md
@@ -330,7 +330,7 @@ mutex.withLock {
 // borrow access ends
 
 do {
-  // borrow access ends
+  // borrow access begins
   let locked = mutex.lock()
   ...
   


### PR DESCRIPTION
It should read begins/ends, not ends/ends.