### PR TITLE
[pitch] Apply the `extracting()` slicing pattern to `Span` & `RawSpan`

### DIFF
--- a/proposals/0488-extracting.md
+++ b/proposals/0488-extracting.md
@@ -1,11 +1,11 @@
 # Apply the extracting() slicing pattern more widely
 
-* Proposal: [TBD](https://github.com/swiftlang/swift-evolution/pull/2877)
+* Proposal: [SE-0488](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0488-extracting.md)
 * Author: [Guillaume Lessard](https://github.com/glessard)
-* Review Manager: TBD
-* Status: **Pitch**
+* Review Manager: [Tony Allevato](https://github.com/allevato)
+* Status: **Active Review (July 2–July 16, 2025)**
 * Implementation: underscored `_extracting()` members of `Span` and `RawSpan`, pending elsewhere.
-* Review: Pending
+* Review: ([pitch](https://forums.swift.org/t/pitch-apply-the-extracting-slicing-pattern-to-span-and-rawspan/80322))
 
 [SE-0437]: 0437-noncopyable-stdlib-primitives.md
 [SE-0447]: 0447-span-access-shared-contiguous-storage.md

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -7,9 +7,9 @@
 * Implementation: underscored `_extracting()` members of `Span` and `RawSpan`, pending elsewhere.
 * Review: Pending
 
-[SE-0437]: proposals/0437-noncopyable-stdlib-primitives.md
-[SE-0447]: proposals/0447-span-access-shared-contiguous-storage.md
-[SE-0467]: proposals/0467-MutableSpan.md
+[SE-0437]: 0437-noncopyable-stdlib-primitives.md
+[SE-0447]: 0447-span-access-shared-contiguous-storage.md
+[SE-0467]: 0467-MutableSpan.md
 [Forum-LifetimeAnnotations]: https://forums.swift.org/t/78638
 
 

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -12,12 +12,12 @@
 [SE-0467]: proposals/0467-MutableSpan.md
 [Forum-LifetimeAnnotations]: https://forums.swift.org/t/78638
 
+
 ## Introduction and Motivation
 
 Slicing containers is an important operation, and non-copyable values have introduced a significant change in the spelling of that operation. When we [introduced][SE-0437] non-copyable primitives to the standard library, we allowed slicing `UnsafeBufferPointer` and related types via a family of `extracting()` methods. We expanded upon these when introducing [`MutableSpan`][SE-0467].
 
 Now that we have a [stable spelling][Forum-LifetimeAnnotations] for lifetime dependencies, we propose adding the `extracting()` methods to `Span` and `RawSpan`, as well as members of the `UnsafeBufferPointer` family that were missed in [SE-0437][SE-0437].
-
 
 
 ## Proposed solution
@@ -28,7 +28,7 @@ The family of `extracting()` methods established by the [`MutableSpan` proposal]
 ```swift
 public func extracting(_ bounds: Range<Index>) -> Self
 public func extracting(_ bounds: some RangeExpression<Index>) -> Self
-public func extracting(_ UnboundedRange) -> Self
+public func extracting(_: UnboundedRange) -> Self
 @unsafe public func extracting(unchecked bounds: Range<Index>) -> Self
 @unsafe public func extracting(unchecked bounds: ClosedRange<Index>) -> Self
 
@@ -38,7 +38,7 @@ public func extracting(last maxLength: Int) -> Self
 public func extracting(droppingFirst k: Int) -> Self
 ```
 
-These should be provided for the following standard library types:
+These will be provided for the following standard library types:
 ```swift
 Span<T>
 RawSpan
@@ -52,6 +52,7 @@ Slice<UnsafeRawBufferPointer>
 Slice<UnsafeMutableRawBufferPointer>
 ```
 Some of the types in the list above already have a subset of the `extracting()` functions; their support will be rounded out to the full set.
+
 
 ## Detailed design
 
@@ -73,7 +74,7 @@ public func extracting(_ byteOffsets: some RangeExpression<Int>) -> Self
 
 /// Returns an extracted slice over all items of this container.
 @_lifetime(copy self)
-public func extracting(_ UnboundedRange) -> Self
+public func extracting(_: UnboundedRange) -> Self
 
 /// Returns an extracted slice over the items within
 /// the supplied range of positions.
@@ -109,7 +110,8 @@ public func extracting(last maxLength: Int) -> Self
 @_lifetime(copy self)
 public func extracting(droppingFirst k: Int) -> Self
 ```
-For non-escapable types, the `@_lifetime` attribute is ignored as being non-applicable.
+For escapable types, the `@_lifetime` attribute is not applied.
+
 
 #### Usage hints
 
@@ -124,7 +126,7 @@ public func droppingFirst(_ k: Int) -> Self { extracting(first: k) }
 ```
 
 ## Source compatibility
-This proposal is additive and source-copmatible with existing code.
+This proposal is additive and source-compatible with existing code.
 
 ## ABI compatibility
 This proposal is additive and ABI-compatible with existing code.

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -113,7 +113,7 @@ public func extracting(droppingFirst k: Int) -> Self
 For escapable types, the `@_lifetime` attribute is not applied.
 
 
-#### Usage hints
+### Usage hints
 
 The `extracting()` pattern, while not completely new, is still a departure over the slice pattern established by the `Collection` protocol. For `Span`, `RawSpan`, `MutableSpan` and `MutableRawSpan`, we can add unavailable subscripts and function with hints towards the corresponding `extracting()` function:
 

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -109,6 +109,18 @@ public func extracting(droppingFirst k: Int) -> Self
 ```
 For non-escapable types, the `@_lifetime` attribute is ignored as being non-applicable.
 
+#### Usage hints
+
+The `extracting()` pattern, while not completely new, is still a departure over the slice pattern established by the `Collection` protocol. For `Span`, `RawSpan`, `MutableSpan` and `MutableRawSpan`, we can add unavailable subscripts and function with hints towards the corresponding `extracting()` function:
+
+```swift
+@available(*, unavailable, renamed: "extracting(_ bounds:)")
+public subscript(bounds: Range<Index>) -> Self { extracting(bounds) }
+
+@available(*, unavailable, renamed: "extracting(first:)")
+public func droppingFirst(_ k: Int) -> Self { extracting(first: k) }
+```
+
 ## Source compatibility
 This proposal is additive and source-copmatible with existing code.
 

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -139,7 +139,7 @@ This is an extension of an existing pattern. We are not considering a different 
 
 ## Future directions
 #### Disambiguation over ownership type
-The `extracting()` functions proposed here are semantically consuming. `MutableSpan` has versions defined as mutations, but it could benefit from consuming ones as well. In order to do this, we could establish a pattern for disambiguation by name, or we could invent new syntax to disambiguate by ownership type. This is a complex topic left to future proposals.
+The `extracting()` functions proposed here are borrowing. `MutableSpan` has versions defined as mutating, but it could benefit from consuming ones as well. In general there could be a need for all three ownership variants of a given operation (`borrowing`, `consuming`, or `mutating`.) In order to handle these variants, we could establish a pattern for disambiguation by name, or we could invent new syntax to disambiguate by ownership type. This is a complex topic left to future proposals.
 
 ## Acknowledgements
 Thanks to Karoy Lorentey and Tony Parker.

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -22,7 +22,9 @@ Now that we have a [stable spelling][Forum-LifetimeAnnotations] for lifetime dep
 
 ## Proposed solution
 
-The family of `extracting()` methods is as follows:
+As previously discussed in [SE-0437][SE-0437], the slicing pattern established by the `Collection` protocol cannot be generalized for either non-copyable elements or non-escapable containers. The solution is a family of functions named `extracting()`, with appropriate argument labels.
+
+The family of `extracting()` methods established by the [`MutableSpan` proposal][SE-0467] is as follows:
 ```swift
 public func extracting(_ bounds: Range<Index>) -> Self
 public func extracting(_ bounds: some RangeExpression<Index>) -> Self

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -1,6 +1,6 @@
 # Apply the extracting() slicing pattern more widely
 
-* Proposal: TBD
+* Proposal: [TBD](https://github.com/swiftlang/swift-evolution/pull/2877)
 * Author: [Guillaume Lessard](https://github.com/glessard)
 * Review Manager: TBD
 * Status: **Pitch**

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -1,0 +1,130 @@
+# Expand the `extracting()` slicing pattern to more types
+
+* Proposal: [SE-0485](0485-outputspan.md)
+* Author: [Guillaume Lessard](https://github.com/glessard)
+* Review Manager: [Doug Gregor](https://github.com/DougGregor)
+* Status: **Pitch**
+* Implementation: underscored `_extracting()` members of `Span` and `RawSpan`, pending elsewhere.
+* Review: Pending
+
+[SE-0437]: proposals/0437-noncopyable-stdlib-primitives.md
+[SE-0447]: proposals/0447-span-access-shared-contiguous-storage.md
+[SE-0467]: proposals/0467-MutableSpan.md
+[Forum-LifetimeAnnotations]: https://forums.swift.org/t/78638
+
+## Introduction and Motivation
+
+Slicing containers is an important operation, and non-copyable values have introduced a significant change in the spelling of that operation. When we [introduced][SE-0437] non-copyable primitives to the standard library, we allowed slicing `UnsafeBufferPointer` and related types via a family of `extracting()` methods. We expanded upon these when introducing [`MutableSpan`][SE-0467].
+
+Now that we have a [stable spelling][Forum-LifetimeAnnotations] for lifetime dependencies, we propose adding the `extracting()` methods to `Span` and `RawSpan`, as well as members of the `UnsafeBufferPointer` family that were missed in [SE-0437][SE-0437].
+
+
+
+## Proposed solution
+
+The family of `extracting()` methods is as follows:
+```swift
+public func extracting(_ bounds: Range<Index>) -> Self
+public func extracting(_ bounds: some RangeExpression<Index>) -> Self
+public func extracting(_ UnboundedRange) -> Self
+@unsafe public func extracting(unchecked bounds: Range<Index>) -> Self
+@unsafe public func extracting(unchecked bounds: ClosedRange<Index>) -> Self
+
+public func extracting(first maxLength: Int) -> Self
+public func extracting(droppingLast k: Int) -> Self
+public func extracting(last maxLength: Int) -> Self
+public func extracting(droppingFirst k: Int) -> Self
+```
+
+These should be provided for the following standard library types:
+```swift
+Span<T>
+RawSpan
+UnsafeBufferPointer<T>
+UnsafeMutableBufferPointer<T>
+Slice<UnsafeBufferPointer<T>>
+Slice<UnsafeMutableBufferPointer<T>>
+UnsafeRawBufferPointer
+UnsafeMutableRawBufferPointer
+Slice<UnsafeRawBufferPointer>
+Slice<UnsafeMutableRawBufferPointer>
+```
+Some of the types in the list above already have a subset of the `extracting()` functions; their support will be rounded out to the full set.
+
+## Detailed design
+
+The general declarations for these functions is as follows:
+```swift
+/// Returns an extracted slice over the items within
+/// the supplied range of positions.
+///
+/// Traps if any position within the range is invalid.
+@_lifetime(copy self)
+public func extracting(_ byteOffsets: Range<Int>) -> Self
+
+/// Returns an extracted slice over the items within
+/// the supplied range of positions.
+///
+/// Traps if any position within the range is invalid.
+@_lifetime(copy self)
+public func extracting(_ byteOffsets: some RangeExpression<Int>) -> Self
+
+/// Returns an extracted slice over all items of this container.
+@_lifetime(copy self)
+public func extracting(_ UnboundedRange) -> Self
+
+/// Returns an extracted slice over the items within
+/// the supplied range of positions.
+///
+/// This function does not validate `bounds`; this is an unsafe operation.
+@unsafe @_lifetime(copy self)
+public func extracting(unchecked bounds: Range<Index>) -> Self
+
+/// Returns an extracted slice over the items within
+/// the supplied range of positions.
+///
+/// This function does not validate `bounds`; this is an unsafe operation.
+@unsafe @_lifetime(copy self)
+public func extracting(unchecked bounds: ClosedRange<Index>) -> Self
+
+/// Returns an extracted slice over the initial elements
+/// of this container, up to the specified maximum length.
+@_lifetime(copy self)
+public func extracting(first maxLength: Int) -> Self
+
+/// Returns an extracted slice excluding
+/// the given number of trailing elements.
+@_lifetime(copy self)
+public func extracting(droppingLast k: Int) -> Self
+
+/// Returns an extracted slice containing the final elements
+/// of this container, up to the given maximum length.
+@_lifetime(copy self)
+public func extracting(last maxLength: Int) -> Self
+
+/// Returns an extracted slice excluding
+/// the given number of initial elements.
+@_lifetime(copy self)
+public func extracting(droppingFirst k: Int) -> Self
+```
+For non-escapable types, the `@_lifetime` attribute is ignored as being non-applicable.
+
+## Source compatibility
+This proposal is additive and source-copmatible with existing code.
+
+## ABI compatibility
+This proposal is additive and ABI-compatible with existing code.
+
+## Implications on adoption
+The additions described in this proposal require a new version of the Swift standard library.
+
+## Alternatives considered
+This is an extension of an existing pattern. We are not considering a different pattern at this time.
+
+## Future directions
+#### Disambiguation over ownership type
+The `extracting()` functions proposed here are semantically consuming. `MutableSpan` has versions defined as mutations, but it could benefit from consuming ones as well. In order to do this, we could establish a pattern for disambiguation by name, or we could invent new syntax to disambiguate by ownership type. This is a complex topic left to future proposals.
+
+## Acknowledgements
+Thanks to Karoy Lorentey and Tony Parker.
+

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -1,8 +1,8 @@
 # Expand the `extracting()` slicing pattern to more types
 
-* Proposal: [SE-0485](0485-outputspan.md)
+* Proposal: TBD
 * Author: [Guillaume Lessard](https://github.com/glessard)
-* Review Manager: [Doug Gregor](https://github.com/DougGregor)
+* Review Manager: TBD
 * Status: **Pitch**
 * Implementation: underscored `_extracting()` members of `Span` and `RawSpan`, pending elsewhere.
 * Review: Pending

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -1,4 +1,4 @@
-# Expand the `extracting()` slicing pattern to more types
+# Apply the extracting() slicing pattern more widely
 
 * Proposal: TBD
 * Author: [Guillaume Lessard](https://github.com/glessard)

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -63,14 +63,14 @@ The general declarations for these functions is as follows:
 ///
 /// Traps if any position within the range is invalid.
 @_lifetime(copy self)
-public func extracting(_ byteOffsets: Range<Int>) -> Self
+public func extracting(_ bounds: Range<Index>) -> Self
 
 /// Returns an extracted slice over the items within
 /// the supplied range of positions.
 ///
 /// Traps if any position within the range is invalid.
 @_lifetime(copy self)
-public func extracting(_ byteOffsets: some RangeExpression<Int>) -> Self
+public func extracting(_ bounds: some RangeExpression<Index>) -> Self
 
 /// Returns an extracted slice over all items of this container.
 @_lifetime(copy self)

--- a/proposals/nnnn-extracting.md
+++ b/proposals/nnnn-extracting.md
@@ -17,7 +17,7 @@
 
 Slicing containers is an important operation, and non-copyable values have introduced a significant change in the spelling of that operation. When we [introduced][SE-0437] non-copyable primitives to the standard library, we allowed slicing `UnsafeBufferPointer` and related types via a family of `extracting()` methods. We expanded upon these when introducing [`MutableSpan`][SE-0467].
 
-Now that we have a [stable spelling][Forum-LifetimeAnnotations] for lifetime dependencies, we propose adding the `extracting()` methods to `Span` and `RawSpan`, as well as members of the `UnsafeBufferPointer` family that were missed in [SE-0437][SE-0437].
+Now that we have a [supported spelling][Forum-LifetimeAnnotations] for lifetime dependencies, we propose adding the `extracting()` methods to `Span` and `RawSpan`, as well as members of the `UnsafeBufferPointer` family that were missed in [SE-0437][SE-0437].
 
 
 ## Proposed solution


### PR DESCRIPTION
We have established the `extracting()` pattern for slicing containers of non-copyable elements already, for `UnsafeBufferPointer<T>` and `MutableSpan<T>`. This proposal extends it to more types, notably `Span<T>` and `RawSpan`, as well as rounding out the functions available in the `UnsafeBufferPointer` family of types.