### PR TITLE
[SE-0466] Disable `@MainActor` inference when type conforms to a SendableMetatype protocol

### DIFF
--- a/proposals/0466-control-default-actor-isolation.md
+++ b/proposals/0466-control-default-actor-isolation.md
@@ -65,6 +65,7 @@ When the default actor isolation is specified as `MainActor`, declarations are i
 * Declarations with inferred actor isolation from a superclass, overridden method, protocol conformance, or member propagation
 * All declarations inside an `actor` type, including static variables, methods, initializers, and deinitializers
 * Declarations that cannot have global actor isolation, including typealiases, import statements, enum cases, and individual accessors
+* Declarations whose primary definition directly conforms to a protocol that inherits `SendableMetatype`
 
 The following code example shows the inferred actor isolation in comments given the code is built with `-default-isolation MainActor`:
 
@@ -107,6 +108,18 @@ struct S: P {
   // @MyActor
   func f() { ... }
 }
+
+nonisolated protocol Q: Sendable { }
+
+// nonisolated
+struct S2: Q { }
+
+nonisolated protocol Q: Sendable { }
+
+// @MainActor
+struct S3 { }
+
+extension S3: Q { }
 ```
 
 This proposal does not change the default isolation inference rules for closures. Non-Sendable closures and closures passed to `Task.init` already have the same isolation as the enclosing context by default. When specifying `MainActor` isolation by default in a module, non-`@Sendable` closures and `Task.init` closures will have inferred `@MainActor` isolation when the default `@MainActor` inference rules apply to the enclosing context:


### PR DESCRIPTION
Libraries need a way to communicate that certain protocols can't reasonably be used with global-actor-isolated types. When the primary definition of a type conforms to such a protocol, it will disable `@MainActor` inference for that type. This has the effect of keeping more types `nonisolated` when there's signal that they should not be on the main actor. There are some protocols like this in the standard library (e.g., CodingKey, which was hardcoded to be nonisolated in the synthesis code), where the following code is ill-formed in with main-actor isolation by default:

    struct S: Codable {
      var a: Int

      // error: CodingKeys inferred to `@MainActor`, which makes the conformance
      // to CodingKey main-actor-isolated and then fails (because the requirements
      // need to be nonisolated).
      enum CodingKeys: CodingKey {
        case a
      }
    }

With this amendment, the conformance to `CodingKey` (which inherits from `Sendable`), prevents `CodingKeys` from being inferred to be`@MainActor`.