### PR TITLE
Fix SE-487 status state

### DIFF
--- a/proposals/0487-extensible-enums.md
+++ b/proposals/0487-extensible-enums.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0487](0487-extensible-enums.md)
 * Authors: [Pavel Yaskevich](https://github.com/xedin), [Franz Busch](https://github.com/FranzBusch), [Cory Benfield](https://github.com/lukasa)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
-* Status: **In active review (July 1 — July 10, 2025)**
+* Status: **Active Review (July 1 — July 10, 2025)**
 * Bug: [apple/swift#55110](https://github.com/swiftlang/swift/issues/55110)
 * Implementation: [apple/swift#80503](https://github.com/swiftlang/swift/pull/80503)
 * Upcoming Feature Flag: `ExtensibleAttribute`


### PR DESCRIPTION
To match https://github.com/swiftlang/swift-evolution-metadata-extractor/blob/0.1.0/Tests/ExtractionTests/Resources/review-dates-good.txt.

Currently:
```bash
curl https://download.swift.org/swift-evolution/v1/evolution.json | jq '.proposals[] | select(.id == "SE-0487") | .errors'
[
  {
    "code": 0,
    "kind": "error",
    "message": "Missing or invalid proposal status.",
    "suggestion": ""
  }
]
```