### PR TITLE
[SE-488] Fix Proposal ID link

### DIFF
--- a/proposals/0488-extracting.md
+++ b/proposals/0488-extracting.md
@@ -1,6 +1,6 @@
 # Apply the extracting() slicing pattern more widely
 
-* Proposal: [SE-0488](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0488-extracting.md)
+* Proposal: [SE-0488](0488-extracting.md)
 * Author: [Guillaume Lessard](https://github.com/glessard)
 * Review Manager: [Tony Allevato](https://github.com/allevato)
 * Status: **Active Review (July 2–July 16, 2025)**


### PR DESCRIPTION
Fixes:
```bash
curl https://download.swift.org/swift-evolution/v1/evolution.json | jq '.proposals[] | select(.id == "SE-0488") | .errors'
[
  {
    "code": 0,
    "kind": "error",
    "message": "Proposal ID link must be a relative link (SE-NNNN)[NNNN-filename.md].",
    "suggestion": ""
  }
]
```