### PR TITLE
Fix sample code in `0428-resolve-distributed-actor-protocols.md`

### DIFF
--- a/proposals/0428-resolve-distributed-actor-protocols.md
+++ b/proposals/0428-resolve-distributed-actor-protocols.md
@@ -90,7 +90,7 @@ The macro must be attached to the a `protocol` declaration that is a `Distribute
 import Distributed 
 
 @Resolvable
-protocol Greeter where ActorSystem: DistributedActorSystem<any Codable> {
+protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func greet(name: String) -> String
 }
 ```


### PR DESCRIPTION
This code caused an error with `ActorSystem` type parameter unbound:

```
import Distributed 

@Resolvable
protocol Greeter where ActorSystem: DistributedActorSystem<any Codable> {
  distributed func greet(name: String) -> String
}
```