### PR TITLE
[SE-0466] Amend to clarify that types within nonisolated types don't get default main actor inference

### DIFF
--- a/proposals/0466-control-default-actor-isolation.md
+++ b/proposals/0466-control-default-actor-isolation.md
@@ -66,6 +66,7 @@ When the default actor isolation is specified as `MainActor`, declarations are i
 * All declarations inside an `actor` type, including static variables, methods, initializers, and deinitializers
 * Declarations that cannot have global actor isolation, including typealiases, import statements, enum cases, and individual accessors
 * Declarations whose primary definition directly conforms to a protocol that inherits `SendableMetatype`
+* Declarations that are types nested within a nonisolated type
 
 The following code example shows the inferred actor isolation in comments given the code is built with `-default-isolation MainActor`:
 
@@ -112,7 +113,13 @@ struct S: P {
 nonisolated protocol Q: Sendable { }
 
 // nonisolated
-struct S2: Q { }
+struct S2: Q {
+  // nonisolated
+  struct Inner { }
+
+  // @MyActor
+  struct IsolatedInner: P
+}
 
 // @MainActor
 struct S3 { }


### PR DESCRIPTION
Based on review discussion with @groue 