### PR TITLE
Update state of ST-0011 to Implemented and link to acceptance

### DIFF
--- a/proposals/testing/0011-issue-handling-traits.md
+++ b/proposals/testing/0011-issue-handling-traits.md
@@ -3,12 +3,12 @@
 * Proposal: [ST-0011](0011-issue-handling-traits.md)
 * Authors: [Stuart Montgomery](https://github.com/stmontgomery)
 * Review Manager: [Paul LeMarquand](https://github.com/plemarquand)
-* Status: **Active Review (Jun 24 - July 8, 2025)**
+* Status: **Implemented (Swift 6.2)**
 * Implementation: [swiftlang/swift-testing#1080](https://github.com/swiftlang/swift-testing/pull/1080),
   [swiftlang/swift-testing#1121](https://github.com/swiftlang/swift-testing/pull/1121),
   [swiftlang/swift-testing#1136](https://github.com/swiftlang/swift-testing/pull/1136),
   [swiftlang/swift-testing#1198](https://github.com/swiftlang/swift-testing/pull/1198)
-* Review: ([pitch](https://forums.swift.org/t/pitch-issue-handling-traits/80019)) ([review](https://forums.swift.org/t/st-0011-issue-handling-traits/80644))
+* Review: ([pitch](https://forums.swift.org/t/pitch-issue-handling-traits/80019)) ([review](https://forums.swift.org/t/st-0011-issue-handling-traits/80644)) ([acceptance](https://forums.swift.org/t/accepted-st-0011-issue-handling-traits/81112))
 
 ## Introduction
 


### PR DESCRIPTION
This is pending integration of this [enablement PR](https://github.com/swiftlang/swift-testing/pull/1228) targeting 6.2. It was previously integrated on main [here](https://github.com/swiftlang/swift-testing/pull/1198).