### PR TITLE
update spelling of my name

### DIFF
--- a/proposals/0184-unsafe-pointers-add-missing.md
+++ b/proposals/0184-unsafe-pointers-add-missing.md
@@ -1,7 +1,7 @@
 # Unsafe[Mutable][Raw][Buffer]Pointer: add missing methods, adjust existing labels for clarity, and remove deallocation size
 
 * Proposal: [SE-0184](0184-unsafe-pointers-add-missing.md)
-* Author: [Dianna Ma (“Taylor Swift”)](https://github.com/tayloraswift)
+* Author: [Diana Ma (“Taylor Swift”)](https://github.com/tayloraswift)
 * Review Manager: [Doug Gregor](https://github.com/DougGregor)
 * Status: **Implemented (Swift 4.1)**
 * Implementation: [apple/swift#12200](https://github.com/apple/swift/pull/12200)

--- a/proposals/0243-codepoint-and-character-literals.md
+++ b/proposals/0243-codepoint-and-character-literals.md
@@ -1,7 +1,7 @@
 # Integer-convertible character literals
 
 * Proposal: [SE-0243](0243-codepoint-and-character-literals.md)
-* Authors: [Dianna Ma (“Taylor Swift”)](https://github.com/tayloraswift), [Chris Lattner](https://github.com/lattner), [John Holdsworth](https://github.com/johnno1962)
+* Authors: [Diana Ma (“Taylor Swift”)](https://github.com/tayloraswift), [Chris Lattner](https://github.com/lattner), [John Holdsworth](https://github.com/johnno1962)
 * Review manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Rejected** ([Rationale](https://forums.swift.org/t/se-0243-codepoint-and-character-literals/21188/341))
 * Implementation: [apple/swift#21873](https://github.com/apple/swift/pull/21873)

--- a/proposals/0266-synthesized-comparable-for-enumerations.md
+++ b/proposals/0266-synthesized-comparable-for-enumerations.md
@@ -1,7 +1,7 @@
 # Synthesized `Comparable` conformance for `enum` types
 
 * Proposal: [SE-0266](0266-synthesized-comparable-for-enumerations.md)
-* Author: [Dianna Ma (taylorswift)](https://github.com/tayloraswift)
+* Author: [Diana Ma (taylorswift)](https://github.com/tayloraswift)
 * Review Manager: [Ben Cohen](https://github.com/airspeedswift)
 * Status: **Implemented (Swift 5.3)**
 * Implementation: [apple/swift#25696](https://github.com/apple/swift/pull/25696)

--- a/proposals/0370-pointer-family-initialization-improvements.md
+++ b/proposals/0370-pointer-family-initialization-improvements.md
@@ -1758,6 +1758,6 @@ One of the pre-existing returned tuples does not have element labels, and the or
 
 ## Acknowledgments
 
-[Dianna Ma](https://github.com/tayloraswift) (aka [Taylor Swift](https://forums.swift.org/u/taylorswift/summary))'s initial versions of the pitch that became SE-0184 included more functions to manipulate initialization state. These were deferred, but much of the deferred functionality has not been pitched again until now.
+[Diana Ma](https://github.com/tayloraswift) (aka [Taylor Swift](https://forums.swift.org/u/taylorswift/summary))'s initial versions of the pitch that became SE-0184 included more functions to manipulate initialization state. These were deferred, but much of the deferred functionality has not been pitched again until now.
 
 Members of the Swift Standard Library team for valuable discussions.


### PR DESCRIPTION
when i got it changed by court order earlier this year, i settled on the spelling *Diana Ma* (with one *n*), which is what i now use on all my legal documents. so i would like the spelling used in this repo to match.