### PR TITLE
[DRAFT] Add a CODEOWNERS file designating oversight of certain Evolution repo directories to relevant teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,47 @@
+# Lines starting with '#' are comments.
+# Each line is a case-sensitive file pattern followed by one or more owners.
+# Order is important. The last matching pattern has the most precedence.
+# More information: https://docs.github.com/en/articles/about-code-owners
+#
+# Please mirror the repository's file hierarchy in case-sensitive lexicographic
+# order.
+
+# .github
+/.github/CODEOWNERS @shahmishal
+
+
+### Evolution process documentation
+
+# The primary Swift Evolution process documentation file.
+/process.md @rjmccall
+
+
+### Vision documents
+
+# The top-level vision documents directory. Approval from the Core Team is
+# required to add new vision documents.
+/visions/ @swiftlang/core-team
+
+# Specific vision documents. Owners typically include the primary author(s) any
+# any relevant steering or workgroups.
+/visions/swift-testing.md @stmontgomery @swiftlang/testing-workgroup
+
+
+### Proposal templates
+
+# The top-level `/proposal-templates` directory. Approval from the Core Team is
+# required to add new proposal templates.
+/proposal-templates/ @swiftlang/core-team
+
+# Specific proposal templates
+/proposal-templates/0000-swift-testing-template.md @swiftlang/testing-workgroup
+
+
+### Proposals
+
+# The top-level `/proposals` directory does not have a designated owner, so its
+# list is empty.
+/proposals
+
+# Swift Testing proposals
+/proposals/testing/ @swiftlang/testing-workgroup


### PR DESCRIPTION
This PR adds a [GitHub `CODEOWNERS` file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) to this repo, assigning ownership and oversight responsibilities for certain content to teams. But (importantly) it leaves the `/proposals` directory without a specific owner.

> **Note:** This PR is a **draft** currently, and I intend to discuss this with the relevant teams before proceeding.

**Motivation**: This originally came up because some of us on the [Testing Workgroup](https://www.swift.org/testing-workgroup/) would like to have greater awareness of PRs which modify proposals and other files related to Swift Testing. When I discovered that there was no `CODEOWNERS` file I drafted the file posted here, which assigns ownership of a few _other_ important files and directories in the repo to people or teams I believe are responsible for them as well. The exact owners listed are of course up for discussion!

My understanding of `CODEOWNERS` files in GitHub (per [documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection)) is that this file alone will not prevent anyone from landing a PR, even if none of the code owners listed have approved it. To begin enforcing such a rule, this repo would need to enable branch protection, and I'm unsure whether that is enabled currently. So this PR, on its own, is not intended to restrict any PRs, although that is a policy we could consider separately.