### PR TITLE
SWT Pitch: Include additional issue metadata in event stream

### DIFF
--- a/proposals/testing/0029-add-issue-metadata-event-stream.md
+++ b/proposals/testing/0029-add-issue-metadata-event-stream.md
@@ -1,9 +1,9 @@
 # Include additional issue metadata in event stream
 
-- Proposal: [ST-NNNN](NNNN-filename.md)
+- Proposal: [ST-0029](0029-add-issue-metadata-event-stream.md)
 - Authors: [Jerry Chen](https://github.com/jerryjrchen)
-- Review Manager: TBD
-- Status: **Awaiting implementation**
+- Review Manager: [Rachel Brindle](https://github.com/younata)
+- Status: **Active Review (Aug 27...Sep 10, 2026)**
 - Implementation:
   [swiftlang/swift-testing#1839](https://github.com/swiftlang/swift-testing/pull/1839)
 - Review:

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -1,0 +1,272 @@
+# Include additional issue metadata in event stream
+
+- Proposal: [ST-NNNN](NNNN-filename.md)
+- Authors: [Jerry Chen](https://github.com/jerryjrchen)
+- Review Manager: TBD
+- Status: **Awaiting implementation**
+- Implementation:
+  [swiftlang/swift-testing#NNNNN](https://github.com/swiftlang/swift-testing/pull/NNNNN)
+- Review: ([pitch](https://forums.swift.org/...))
+
+## Introduction
+
+The event stream provides a stable interface for external tools to read test
+events. When encountering an issue while running tests, Swift Testing generates
+an event which includes a limited amount of issue metadata. We propose enriching
+this metadata with additional fields.
+
+## Motivation
+
+Tools such as Xcode and VS Code can consume the "issue recorded" event from
+Swift Testing's JSON event stream and use that to present test failure details
+to the user. However, there isn't enough structured information present to
+distinguish between different kinds of issues.
+
+For example, the following test fail due to different kinds of issues:
+
+```swift
+@Test func `Issue A`() async throws {
+    Issue.record("Issue A")
+}
+@Test func `Issue B`() async throws {
+    struct ErrorB: Error {}
+    throw ErrorB()
+}
+```
+
+The event stream will contain similar issue metadata for both, differing only in
+their `sourceLocation`:
+
+```json
+"issue": {
+  "isFailure": true,
+  "isKnown": false,
+  "severity": "error",
+  "sourceLocation": { ... }
+}
+```
+
+With the proposed solution, tools can access additional metadata to distinguish
+between issue types and provide richer context for test failures to their end
+users.
+
+## Proposed solution
+
+We propose adding new fields to the issue event type.
+
+## Detailed design
+
+These changes are proposed for event stream schema version `6.5`.
+
+These new fields provide structured information about issues that previously
+weren't available in a machine-readable form.
+
+- **Error:** an error was thrown.
+
+- **Miscount:** a miscount of something led to this issue. Currently, Swift
+  Testing will fill this if a confirmation was confirmed more/fewer times than
+  expected.
+
+- **Time limit:** the test exceeded a time limit. The unit is seconds, which
+  follows the precedent set in an
+  [earlier event stream proposal](./0019-include-tags-bugs-and-timeline-in-event-stream.md).
+
+- **Known issue comment:** if a known issue [that was expected but did not
+  occur at test time][resolve-a-known-issue] has a human-readable comment, it
+  is included as the value of the existing `"isKnown"` field.
+
+[resolve-a-known-issue]:
+  https://developer.apple.com/documentation/Testing/known-issues#Resolve-a-known-issue
+
+- **Expression:** the expression associated with the issue. This is primarily
+  used to capture the body of a failed expectation. However, it can also
+  describe a confirmation that was miscounted.
+
+The following field is added for all events:
+
+- **Comments:** a common event field that stores user provided comments.
+
+  For issues, users can supply comments when recording issues or creating
+  expectations, e.g. `Issue.record("A comment")` or
+  `#expect(a == b, "A comment")`.
+
+### Schema changes
+
+We propose the following changes to the [event stream JSON schema][].
+
+[event stream JSON schema]:
+  https://github.com/swiftlang/swift-testing/blob/main/Documentation/ABI/JSON.md
+
+- `comment` and `time` are currently type aliases which unify references to
+  their respective concepts throughout the schema. In the future, we could
+  easily change the definition of these types to more complex nested structures.
+
+- `numeric-range` is limited, for simplicity, to representing inclusive bounds.
+
+<!-- TODO: we might need to support exclusive bounds since the confirmation
+range is a RangeExpression which could be a Range and not just a ClosedRange-->
+
+```diff
++<comment> ::= <string> ; human-readable, developer-supplied text
+
++<time> ::= <number> ; a timestamp or duration expressed in (floating-point) seconds
+
++<numeric-range> ::= {
++  ["min": <number>,] ; lower-bound, inclusive
++  ["max": <number>] ; upper-bound, inclusive, must be ≥ min (if present)
++}
+```
+
+```diff
+<event> ::= {
+...
++  ["comments": <array:comment>,] ; comments provided by the test author
+}
+
+<issue> ::= {
+ ...
++  ["expression": <expression>,] ; an expression associated with the issue
++  ["error": <error>,] ; the associated error or exception if produced by a language that supports them
++  ["miscount": <miscount>,] ; an associated miscount (too high or too low)
++  ["exceededTimeLimit": <time>,] ; the time limit, in seconds, for the test that was exceeded
+-  "isKnown": <bool>,
++  ["isKnown": <bool> | <comment>] ; whether the issue is known (optionally, the comment associated with the known issue)
+}
+
++<error> ::= {
++  ["code": <number>,]
++  ["domain": <string>,]
++  ["description": <string>,]
++  ["type": <type-info>]
++}
+
++<miscount> ::= {
++  "actual": <number>,
++  "expected": <number> ; when the confirmation specifies a single count
++            | <numeric-range> ; when the confirmation specifies a range
++}
+
++<expression> ::= {
++  "sourceCode": <string>, ; unmodified source code
++  ["value": <expression-value>,] ; the expression's value if available
++  ["type": <type-info>,] ; type for the runtime value
++  ["children": <array:expression>] ; subexpressions, if present
++}
++
++<expression-value> ::= <string> ; a description of the value
++                       | <number> ; the value, if numeric
+
+```
+
+`type-info` will support types from all languages, not just Swift, so only
+applicable fields will be present. For example, C doesn't have fully qualified
+names nor mangle names.
+
+```diff
++<type-info> ::= {
++  ["fullyQualifiedName": <string>,]  ; e.g. "Swift.Bool", "std::string"
++  ["unqualifiedName": <string>,]   ; e.g. "Bool", "string"
++  ["mangledName": <string>,] ; e.g. "Sb", "NSt3__112basic_string..." not necessarily Swift mangling
++}
+```
+
+<!-- TODO: Impl details:
+- Fill in <comment> elsewhere in the JSON ABI spec
+- Fill in <time> elsewhere in the JSON ABI spec
+
+- Disambiguate the other issue kinds without any associated values: known issue not recorded, api misuse, system
+-->
+
+### Sample JSON output
+
+<!-- TODO: after demo impl is ready -->
+
+## Source compatibility
+
+There are no source compatibility concerns.
+
+## Integration with supporting tools
+
+The definition of the `isKnown` field will change from the 6.4 schema. It will
+no longer be a required boolean-valued field, and will instead be an optional
+boolean-valued or string-valued field.
+
+All other fields are purely additive to the JSON ABI.
+
+Existing tools that integrate with Swift Testing will need to update their
+integration code to read the new fields. For example, the implementation of
+targeted interoperability needs to be updated to read the error from the
+`EncodedIssue` type.
+
+## Future directions
+
+- We'd like to add **parameterised test information,** specifically test
+  function definitions and test cases with argument lists, to the event stream.
+  Because test authors can provide a large number of arguments to generate many
+  tests, this faces the extra challenge of ensuring the event stream remains
+  performant. Therefore, this work deserves additional scrutiny in a follow-up
+  proposal.
+
+<!-- TODO: check the current status of symbolication on Linux -->
+
+- We considered including the **issue backtrace** as an optional field. However,
+  as of this proposal, there is no yet a way to symbolicate `Issue` backtrace
+  addresses on Linux. Furthermore, in-process symbolication is an expensive
+  operation, so the design will warrant additional care and scrutiny. Issue
+  backtrace can be added in a follow-up proposal once there are solutions to
+  both of these challenges.
+
+- We'd also like to include **exception information** in the issue event.
+  Although Swift doesn't use exceptions for error handling, test code may
+  interoperate with languages which do (e.g. Objective-C, Java). The `error`
+  field in the issue metadata may be a good candidate to place exception
+  metadata, but exceptions do not share many of the same fields (code, domain,
+  type) as errors in Swift.
+
+## Alternatives considered
+
+### Issue kind
+
+We considered introducing a "kind" field to issue, which follows the existing
+pattern set by event kind:
+
+```diff
+<issue> ::= {
+ ...
++  "kind": <issue-kind>
+}
+
++<issue-kind> ::= "unconditional" | "expectationFailed" | "confirmationMiscounted" | ...
+
+<event> ::= {
+  "kind": <event-kind>,
+  ...
+}
+
+<event-kind> ::= "runStarted" | "testStarted" | "testCaseStarted" | ...
+```
+
+However, issue kind is primarily an implementation detail of the testing
+library, and not all tools that consume test events support all the issue kinds
+that the testing library emits.
+
+Furthermore, tools can derive the same information that issue kind provides by
+inspecting the issue fields. For example, presence of an `miscount` field
+indicates this issue was the "confirmationMiscounted" kind.
+
+### Backtraces
+
+We deliberately picked issue fields that would be relevant to issues created by
+other test libraries besides Swift Testing.
+
+For example, the `Issue` structure contains backtrace addresses which could be
+included in the JSON ABI. However, addresses wouldn't be relevant in a
+[backtrace for an interpreted language like Python][python-traceback].
+
+[python-traceback]:
+  https://docs.python.org/3/reference/datamodel.html#traceback-objects
+
+## Acknowledgments
+
+Thanks to Jonathan Grynspan and Stuart Montgomery for providing feedback on the
+proposal.

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -118,6 +118,12 @@ The following field is added for all events:
   User-provided comments for `withKnownIssue` are not included here, and are
   instead included in the `isKnown` field.
 
+- **Source Location:** this field is already present in the issue schema, but
+  the event stream can include the source location for other event kinds: value
+  attached and skipped test cases.
+
+  Since it is a shared field, this proposal moves it to the top-level `<event>`.
+
 ### Schema changes
 
 We propose the following changes to the [event stream JSON schema][]:
@@ -152,6 +158,7 @@ Events changes:
 +  ["comments": <array:comment>,] ; comments provided by the test author
 -  "messages": <array:message>,
 +  ["messages": <array:message>,] ; messages become optional and are omitted by default
++  ["sourceLocation": <source-location>,] ; source location is moved to the top level event
 }
 
 <issue> ::= {
@@ -162,6 +169,7 @@ Events changes:
 +  ["exceededTimeLimit": <time>,] ; the time limit, in seconds, that was exceeded
 -  "isKnown": <bool>,
 +  ["isKnown": <bool> | <comment>] ; whether the issue is known (optionally, the comment associated with the known issue)
+-  ["sourceLocation": <source-location>,] ; Moved to <event>
 }
 
 +<error> ::= {
@@ -470,6 +478,9 @@ Changes from the 6.4 schema:
   be an optional boolean-valued or string-valued field.
 
 - `messages` field becomes optional.
+
+- `sourceLocation` field moves to `<event>` out of the individual event
+  structures.
 
 - All other fields are purely additive to the JSON ABI.
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -105,7 +105,7 @@ Modify these pre-existing fields:
   serializing this redundant field.
 
   Tools can continue to receive messages in the event stream using the
-  environment variable `SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED`.
+  environment variable `SWIFT_TESTING_EVENT_STREAM_MESSAGES_FIELD_ENABLED`.
 
 The following field is added for all events:
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -53,6 +53,17 @@ With the proposed solution, tools can access additional metadata to distinguish
 between issue types and provide richer context for test failures to their end
 users.
 
+### Support languages and libraries beyond Swift and Swift Testing
+
+We envision that tools which consume Swift Testing events can also support other
+test libraries and their respective test events. If Swift Testing defines an
+issue schema that can be re-used for issues across testing libraries, tools can
+take advantage of the format to unify their issue handling logic for different
+test libraries.
+
+Therefore, we designed new data types to support languages other than Swift, and
+ensured that new issue fields would be relevant for other testing libraries.
+
 ## Proposed solution
 
 We propose adding new fields to the issue event type.

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -126,9 +126,9 @@ range is a RangeExpression which could be a Range and not just a ClosedRange-->
 <issue> ::= {
  ...
 +  ["expression": <expression>,] ; an expression associated with the issue
-+  ["error": <error>,] ; the associated error or exception if produced by a language that supports them
++  ["error": <error>,] ; the associated error or exception, if any
 +  ["miscount": <miscount>,] ; an associated miscount (too high or too low)
-+  ["exceededTimeLimit": <time>,] ; the time limit, in seconds, for the test that was exceeded
++  ["exceededTimeLimit": <time>,] ; the time limit, in seconds, that was exceeded
 -  "isKnown": <bool>,
 +  ["isKnown": <bool> | <comment>] ; whether the issue is known (optionally, the comment associated with the known issue)
 }
@@ -160,7 +160,7 @@ range is a RangeExpression which could be a Range and not just a ClosedRange-->
 
 `type-info` will support types from all languages, not just Swift, so only
 applicable fields will be present. For example, C doesn't have fully qualified
-names nor mangle names.
+names nor, in most implementations, mangled names.
 
 ```diff
 +<type-info> ::= {
@@ -216,7 +216,7 @@ targeted interoperability needs to be updated to read the error from the
   backtrace can be added in a follow-up proposal once there are solutions to
   both of these challenges.
 
-- We'd also like to include **exception information** in the issue event.
+- We'd also like to include **exception information** in the `<issue>` structure.
   Although Swift doesn't use exceptions for error handling, test code may
   interoperate with languages which do (e.g. Objective-C, Java). The `error`
   field in the issue metadata may be a good candidate to place exception

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -71,9 +71,9 @@ weren't available in a machine-readable form.
   follows the precedent set in an
   [earlier event stream proposal](./0019-include-tags-bugs-and-timeline-in-event-stream.md).
 
-- **Known issue comment:** if a known issue [that was expected but did not
-  occur at test time][resolve-a-known-issue] has a human-readable comment, it
-  is included as the value of the existing `"isKnown"` field.
+- **Known issue comment:** if a known issue [that was expected but did not occur
+  at test time][resolve-a-known-issue] has a human-readable comment, it is
+  included as the value of the existing `"isKnown"` field.
 
 [resolve-a-known-issue]:
   https://developer.apple.com/documentation/Testing/known-issues#Resolve-a-known-issue
@@ -126,7 +126,7 @@ range is a RangeExpression which could be a Range and not just a ClosedRange-->
 <issue> ::= {
  ...
 +  ["expression": <expression>,] ; an expression associated with the issue
-+  ["error": <error>,] ; the associated error or exception, if any
++  ["error": <error>,] ; the associated error, if any
 +  ["miscount": <miscount>,] ; an associated miscount (too high or too low)
 +  ["exceededTimeLimit": <time>,] ; the time limit, in seconds, that was exceeded
 -  "isKnown": <bool>,
@@ -166,14 +166,14 @@ names nor, in most implementations, mangled names.
 +<type-info> ::= {
 +  ["fullyQualifiedName": <string>,]  ; e.g. "Swift.Bool", "std::string"
 +  ["unqualifiedName": <string>,]   ; e.g. "Bool", "string"
-+  ["mangledName": <string>,] ; e.g. "Sb", "NSt3__112basic_string..." not necessarily Swift mangling
++  ["mangledName": <string>,] ; e.g. "Sb", "NSt3__112basic_string..."
+   (std::string mangling on )
 +}
 ```
 
 <!-- TODO: Impl details:
 - Fill in <comment> elsewhere in the JSON ABI spec
 - Fill in <time> elsewhere in the JSON ABI spec
-
 - Disambiguate the other issue kinds without any associated values: known issue not recorded, api misuse, system
 -->
 
@@ -200,32 +200,26 @@ targeted interoperability needs to be updated to read the error from the
 
 ## Future directions
 
-- We'd like to add **parameterised test information,** specifically test
-  function definitions and test cases with argument lists, to the event stream.
-  Because test authors can provide a large number of arguments to generate many
-  tests, this faces the extra challenge of ensuring the event stream remains
-  performant. Therefore, this work deserves additional scrutiny in a follow-up
-  proposal.
-
 <!-- TODO: check the current status of symbolication on Linux -->
 
 - We considered including the **issue backtrace** as an optional field. However,
   as of this proposal, there is no yet a way to symbolicate `Issue` backtrace
   addresses on Linux. Furthermore, in-process symbolication is an expensive
-  operation, so the design will warrant additional care and scrutiny. Issue
-  backtrace can be added in a follow-up proposal once there are solutions to
-  both of these challenges.
+  operation, so the design will warrant additional care and scrutiny.
 
-- We'd also like to include **exception information** in the `<issue>` structure.
-  Although Swift doesn't use exceptions for error handling, test code may
-  interoperate with languages which do (e.g. Objective-C, Java). The `error`
+  Issue backtrace can be added in a follow-up proposal once there are solutions
+  to both of these challenges. For consistency, the backtrace field should be
+  included in the API for the `Issue` structure at the time it is included in
+  the JSON schema.
+
+- We'd also like to include **exception information** in the `<issue>`
+  structure. Although Swift doesn't use exceptions for error handling, test code
+  may interoperate with languages which do (e.g. Objective-C, Java). The `error`
   field in the issue metadata may be a good candidate to place exception
   metadata, but exceptions do not share many of the same fields (code, domain,
   type) as errors in Swift.
 
 ## Alternatives considered
-
-### Issue kind
 
 We considered introducing a "kind" field to issue, which follows the existing
 pattern set by event kind:
@@ -253,18 +247,6 @@ that the testing library emits.
 Furthermore, tools can derive the same information that issue kind provides by
 inspecting the issue fields. For example, presence of an `miscount` field
 indicates this issue was the "confirmationMiscounted" kind.
-
-### Backtraces
-
-We deliberately picked issue fields that would be relevant to issues created by
-other test libraries besides Swift Testing.
-
-For example, the `Issue` structure contains backtrace addresses which could be
-included in the JSON ABI. However, addresses wouldn't be relevant in a
-[backtrace for an interpreted language like Python][python-traceback].
-
-[python-traceback]:
-  https://docs.python.org/3/reference/datamodel.html#traceback-objects
 
 ## Acknowledgments
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -118,6 +118,10 @@ The following field is added for all events:
   User-provided comments for `withKnownIssue` are not included here, and are
   instead included in the `isKnown` field.
 
+- **Source Location:** this field is already present in the issue schema, but it
+  also appears for other event types. Since it is a shared field, this proposal
+  moves it to the top-level `<event>`.
+
 ### Schema changes
 
 We propose the following changes to the [event stream JSON schema][]:
@@ -152,6 +156,7 @@ Events changes:
 +  ["comments": <array:comment>,] ; comments provided by the test author
 -  "messages": <array:message>,
 +  ["messages": <array:message>,] ; messages become optional and are omitted by default
++  ["sourceLocation": <source-location>,] ; source location is moved to the top level event
 }
 
 <issue> ::= {
@@ -162,6 +167,19 @@ Events changes:
 +  ["exceededTimeLimit": <time>,] ; the time limit, in seconds, that was exceeded
 -  "isKnown": <bool>,
 +  ["isKnown": <bool> | <comment>] ; whether the issue is known (optionally, the comment associated with the known issue)
+-  ["sourceLocation": <source-location>,] ; Moved to <event>
+}
+
+
+<test-suite> ::= {
+  ...
+-  "sourceLocation": <source-location>, ; Moved to <event>
+}
+
+
+<test-function> ::= {
+  ...
+-  "sourceLocation": <source-location>, ; Moved to <event>
 }
 
 +<error> ::= {
@@ -470,6 +488,9 @@ Changes from the 6.4 schema:
   be an optional boolean-valued or string-valued field.
 
 - `messages` field becomes optional.
+
+- `sourceLocation` field moves to `<event>` out of the individual event
+  structures.
 
 - All other fields are purely additive to the JSON ABI.
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -73,12 +73,13 @@ weren't available in a machine-readable form:
   follows the precedent set in an
   [earlier event stream proposal](./0019-include-tags-bugs-and-timeline-in-event-stream.md).
 
-- **Known issue comment:** if a known issue [that was expected but did not occur
-  at test time][resolve-a-known-issue] has a human-readable comment, it is
-  included as the value of the existing `"isKnown"` field.
+<!-- TODO: Not sure if it would just be better to keep this field as non-optional -->
 
-[resolve-a-known-issue]:
-  https://developer.apple.com/documentation/Testing/known-issues#Resolve-a-known-issue
+- **Known issue comment:** if an [issue was marked as known][known-issues] with
+  a human-readable comment, it is included as the value of the existing
+  `"isKnown"` field.
+
+[known-issues]: https://developer.apple.com/documentation/Testing/known-issues
 
 - **Expression:** the expression associated with the issue. This is primarily
   used to capture the body of a failed expectation. However, it can also
@@ -106,9 +107,6 @@ New common data types:
   easily change the definition of these types to more complex nested structures.
 
 - `numeric-range` is limited, for simplicity, to representing inclusive bounds.
-
-<!-- TODO: we might need to support exclusive bounds since the confirmation
-range is a RangeExpression which could be a Range and not just a ClosedRange-->
 
 ```diff
 +<comment> ::= <string> ; human-readable, developer-supplied text
@@ -176,18 +174,54 @@ names nor, in most implementations, mangled names.
 +<type-info> ::= {
 +  ["fullyQualifiedName": <string>,]  ; e.g. "Swift.Bool", "std::string"
 +  ["unqualifiedName": <string>,]   ; e.g. "Bool", "string"
-+  ["mangledName": <string>,] ; e.g. "Sb", "NSt3__112basic_string..."
++  ["mangledName": <string>,] ; e.g. "$sSb", "_ZNSt3__112basic_string..."
 +}
 ```
+
+### Sample JSON output
 
 <!-- TODO: Impl details:
 - Fill in <comment> elsewhere in the JSON ABI spec
 - Fill in <time> elsewhere in the JSON ABI spec
 -->
 
-### Sample JSON output
-
 <!-- TODO: after demo impl is ready -->
+<!--TODO: open qs:
+- Hard to disambiguate the withKnownIssue not matched
+- We might need to support exclusive bounds since the confirmation range is a RangeExpression which could be a Range and not just a ClosedRange
+-->
+
+<!-- TODO: Need example of mangled name in output as well? -->
+
+<!--
+
+```swift
+Issue.record("Issue recorded with user comment")
+```
+
+```swift
+#expect(Bool(false), "Expectation fail with user comment")
+```
+
+```swift
+struct SampleError: Error {}
+throw SampleError()
+```
+
+#### Known Issue
+
+```swift
+withKnownIssue("This issue is known") {
+  Issue.record("Some failure")
+}
+```
+
+```swift
+withKnownIssue("Expected an issue but none recorded") {
+  // Intentionally blank with nothing to match
+}
+```
+-->
 
 ## Source compatibility
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -5,8 +5,9 @@
 - Review Manager: TBD
 - Status: **Awaiting implementation**
 - Implementation:
-  [swiftlang/swift-testing#NNNNN](https://github.com/swiftlang/swift-testing/pull/NNNNN)
-- Review: ([pitch](https://forums.swift.org/t/pitch-add-issue-fields-to-json-abi-schema/88898))
+  [swiftlang/swift-testing#1839](https://github.com/swiftlang/swift-testing/pull/1839)
+- Review:
+  ([pitch](https://forums.swift.org/t/pitch-add-issue-fields-to-json-abi-schema/88898))
 
 ## Introduction
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -216,7 +216,7 @@ names nor, in most implementations, mangled names.
 
 `Issue.record("Issue recorded with user comment")`
 
-```
+```json
 {
   "kind": "event",
   "payload": {
@@ -226,9 +226,9 @@ names nor, in most implementations, mangled names.
     "instant": { ... },
     "issue": {
       "isFailure": true,
-      "severity": "error",
-      "sourceLocation": { ... }
+      "severity": "error"
     },
+    "sourceLocation": { ... },
     "iteration": 1,
     "kind": "issueRecorded",
     "testID": "SampleTests.`Issue record`()/SampleTests.swift:3:2"
@@ -244,32 +244,32 @@ struct SampleError: Error {}
 throw SampleError()
 ```
 
-```
+```json
 {
   "kind": "event",
-    "payload": {
-      "comments": [],
-      "instant": { ... },
-      "issue": {
-        "error": {
-          "code": 1,
-          "description": "SampleError()",
-          "domain": "SampleTests.(unknown context at $109ada6ac).(unknown context at $109ada6b8).SampleError",
-          "type": {
-            "fullyQualifiedName": "SampleTests.SampleError",
-            "mangledName": "$s11SampleTests10$109ada6acyXZ10$109ada6b8yXZ0A5ErrorV",
-            "unqualifiedName": "SampleError"
-          }
-        },
-        "isFailure": true,
-        "severity": "error",
-        "sourceLocation": { ... }
+  "payload": {
+    "comments": [],
+    "instant": { ... },
+    "issue": {
+      "error": {
+        "code": 1,
+        "description": "SampleError()",
+        "domain": "SampleTests.(unknown context at $109ada6ac).(unknown context at $109ada6b8).SampleError",
+        "type": {
+          "fullyQualifiedName": "SampleTests.SampleError",
+          "mangledName": "$s11SampleTests10$109ada6acyXZ10$109ada6b8yXZ0A5ErrorV",
+          "unqualifiedName": "SampleError"
+        }
       },
-      "iteration": 1,
-      "kind": "issueRecorded",
-      "testID": "SampleTests.`Thrown error`()/SampleTests.swift:11:2"
+      "isFailure": true,
+      "severity": "error"
     },
-    "version": "6.5.0"
+    "sourceLocation": { ... },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Thrown error`()/SampleTests.swift:11:2"
+  },
+  "version": "6.5.0"
 }
 ```
 
@@ -277,66 +277,66 @@ throw SampleError()
 
 `#expect(Bool(false), "Expectation fail with user comment")`
 
-```
+```json
 {
   "kind": "event",
-    "payload": {
-      "comments": [
-        "Expectation fail with user comment"
-      ],
-      "instant": { ... },
-      "issue": {
-        "expression": {
-          "children": [
-          {
-            "sourceCode": "false",
-            "type": {
-              "fullyQualifiedName": "()",
-              "mangledName": "$syt",
-              "unqualifiedName": "()"
-            },
-            "value": "()"
-          }
-          ],
-            "sourceCode": "Bool(false)",
-            "type": {
-              "fullyQualifiedName": "Swift.Bool",
-              "mangledName": "$sSb",
-              "unqualifiedName": "Bool"
-            },
-            "value": "false"
-        },
-        "isFailure": true,
-        "severity": "error",
-        "sourceLocation": { ... }
+  "payload": {
+    "comments": [
+      "Expectation fail with user comment"
+    ],
+    "instant": { ... },
+    "issue": {
+      "expression": {
+        "children": [
+        {
+          "sourceCode": "false",
+          "type": {
+            "fullyQualifiedName": "()",
+            "mangledName": "$syt",
+            "unqualifiedName": "()"
+          },
+          "value": "()"
+        }
+        ],
+          "sourceCode": "Bool(false)",
+          "type": {
+            "fullyQualifiedName": "Swift.Bool",
+            "mangledName": "$sSb",
+            "unqualifiedName": "Bool"
+          },
+          "value": "false"
       },
-      "iteration": 1,
-      "kind": "issueRecorded",
-      "testID": "SampleTests.`Expectation failed`()/SampleTests.swift:7:2"
+      "isFailure": true,
+      "severity": "error"
     },
-    "version": "6.5.0"
+    "sourceLocation": { ... },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Expectation failed`()/SampleTests.swift:7:2"
+  },
+  "version": "6.5.0"
 }
 ```
 
 #### Test timeout: `@Test(.timeLimit(.minutes(1)))`
 
-```
+```json
 {
   "kind": "event",
-    "payload": {
-      "comments": [],
-      "instant": { ... },
-      "issue": {
-        "exceededTimeLimit": 60,
-        "isFailure": true,
-        "severity": "error",
-        "sourceLocation": { ... }
-      },
-      "iteration": 1,
-      "kind": "issueRecorded",
-      "testID": "SampleTests.`Time limit exceeded`()/SampleTests.swift:46:2"
+  "payload": {
+    "comments": [],
+    "instant": { ... },
+    "issue": {
+      "exceededTimeLimit": 60,
+      "isFailure": true,
+      "severity": "error"
     },
-    "version": "6.5.0"
+    "sourceLocation": { ... },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Time limit exceeded`()/SampleTests.swift:46:2"
+  },
+  "version": "6.5.0"
 }
 ```
 
@@ -350,25 +350,25 @@ withKnownIssue("This matches and doesn't fail") {
 }
 ```
 
-```
+```json
 {
   "kind": "event",
-    "payload": {
-      "comments": [
-        "This is the known issue"
-      ],
-      "instant": { ... },
-      "issue": {
-        "isFailure": false,
-        "isKnown": "This matches and doesn't fail",
-        "severity": "error",
-        "sourceLocation": { ... }
-      },
-      "iteration": 1,
-      "kind": "issueRecorded",
-      "testID": "SampleTests.`Known issue, matched`()/SampleTests.swift:16:2"
+  "payload": {
+    "comments": [
+      "This is the known issue"
+    ],
+    "instant": { ... },
+    "issue": {
+      "isFailure": false,
+      "isKnown": "This matches and doesn't fail",
+      "severity": "error"
     },
-    "version": "6.5.0"
+    "sourceLocation": { ... },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Known issue, matched`()/SampleTests.swift:16:2"
+  },
+  "version": "6.5.0"
 }
 ```
 
@@ -380,24 +380,24 @@ withKnownIssue("This doesn't match and thus fails") {
 }
 ```
 
-```
+```json
 {
   "kind": "event",
-    "payload": {
-      "comments": [
-        "This doesn't match and thus fails"
-      ],
-      "instant": { ... },
-      "issue": {
-        "isFailure": true,
-        "severity": "error",
-        "sourceLocation": { ... }
-      },
-      "iteration": 1,
-      "kind": "issueRecorded",
-      "testID": "SampleTests.`Known issue, NOT matched`()/SampleTests.swift:22:2"
+  "payload": {
+    "comments": [
+      "This doesn't match and thus fails"
+    ],
+    "instant": { ... },
+    "issue": {
+      "isFailure": true,
+      "severity": "error"
     },
-    "version": "6.5.0"
+    "sourceLocation": { ... },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Known issue, NOT matched`()/SampleTests.swift:22:2"
+  },
+  "version": "6.5.0"
 }
 ```
 
@@ -407,26 +407,26 @@ withKnownIssue("This doesn't match and thus fails") {
 
 `await confirmation { _ in }`
 
-```
+```json
 {
   "kind": "event",
-    "payload": {
-      "comments": [],
-      "instant": { ... },
-      "issue": {
-        "confirmationMiscount": {
-          "actual": 0,
-          "expected": 1
-        },
-        "isFailure": true,
-        "severity": "error",
-        "sourceLocation": { ... }
+  "payload": {
+    "comments": [],
+    "instant": { ... },
+    "issue": {
+      "confirmationMiscount": {
+        "actual": 0,
+        "expected": 1
       },
-      "iteration": 1,
-      "kind": "issueRecorded",
-      "testID": "SampleTests.`Confirmation miscount, expected single`()/SampleTests.swift:42:2"
+      "isFailure": true,
+      "severity": "error"
     },
-    "version": "6.5.0"
+    "sourceLocation": { ... },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Confirmation miscount, expected single`()/SampleTests.swift:42:2"
+  },
+  "version": "6.5.0"
 }
 ```
 
@@ -440,7 +440,7 @@ await confirmation(expectedCount: 1...5) { confirmation in
 }
 ```
 
-```
+```json
 {
   "kind": "event",
   "payload": {
@@ -455,9 +455,9 @@ await confirmation(expectedCount: 1...5) { confirmation in
         }
       },
       "isFailure": true,
-      "severity": "error",
-      "sourceLocation": { ... }
+      "severity": "error"
     },
+    "sourceLocation": { ... },
     "iteration": 1,
     "kind": "issueRecorded",
     "testID": "SampleTests.`Confirmation miscount, expected range`()/SampleTests.swift:34:2"

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -120,6 +120,7 @@ New common data types:
   easily change the definition of these types to more complex nested structures.
 
 - `numeric-range` is limited, for simplicity, to representing inclusive bounds.
+  Both bounds, if present, must be integer-valued, otherwise they are ignored.
 
 ```diff
 +<comment> ::= <string> ; human-readable, developer-supplied text
@@ -160,7 +161,7 @@ Events changes:
 +}
 
 +<miscount> ::= {
-+  "actual": <number>,
++  "actual": <number>, ; integer-valued actual confirmation count
 +  "expected": <number> ; when the confirmation specifies a single count
 +            | <numeric-range> ; when the confirmation specifies a range
 +}
@@ -173,9 +174,16 @@ Events changes:
 +}
 +
 +<expression-value> ::= <string> ; a description of the value
-+                       | <number> ; the value, if numeric
 
 ```
+
+<!-- TODO
++                       | <number> ; the value, if numeric
+Support for numeric values? For integer values, it might be confusing to have
+them appear as floats (e.g. 5 -> 5.0) after the conversion to a JS number. For
+simplicity, keep the expression value as a description of the value (e.g. 5 ->
+"5" for numerics)
+-->
 
 `type-info` will support types from all languages, not just Swift, so only
 applicable fields will be present. For example, C doesn't have fully qualified

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -59,13 +59,15 @@ We propose adding new fields to the issue event type.
 These changes are proposed for event stream schema version `6.5`.
 
 These new fields provide structured information about issues that previously
-weren't available in a machine-readable form.
+weren't available in a machine-readable form:
 
 - **Error:** an error was thrown.
 
 - **Miscount:** a miscount of something led to this issue. Currently, Swift
   Testing will fill this if a confirmation was confirmed more/fewer times than
   expected.
+
+<!-- TODO: Consider a more specific field name e.g. "confirmationMiscount"-->
 
 - **Time limit:** the test exceeded a time limit. The unit is seconds, which
   follows the precedent set in an
@@ -92,10 +94,12 @@ The following field is added for all events:
 
 ### Schema changes
 
-We propose the following changes to the [event stream JSON schema][].
+We propose the following changes to the [event stream JSON schema][]:
 
 [event stream JSON schema]:
   https://github.com/swiftlang/swift-testing/blob/main/Documentation/ABI/JSON.md
+
+New common data types:
 
 - `comment` and `time` are currently type aliases which unify references to
   their respective concepts throughout the schema. In the future, we could
@@ -117,10 +121,16 @@ range is a RangeExpression which could be a Range and not just a ClosedRange-->
 +}
 ```
 
+Events changes:
+
+<!-- TODO: fill out justification for messages -->
+
 ```diff
 <event> ::= {
 ...
 +  ["comments": <array:comment>,] ; comments provided by the test author
+-  "messages": <array:message>,
++  ["messages": <array:message>,] ; messages become optional and are omitted by default
 }
 
 <issue> ::= {
@@ -167,14 +177,12 @@ names nor, in most implementations, mangled names.
 +  ["fullyQualifiedName": <string>,]  ; e.g. "Swift.Bool", "std::string"
 +  ["unqualifiedName": <string>,]   ; e.g. "Bool", "string"
 +  ["mangledName": <string>,] ; e.g. "Sb", "NSt3__112basic_string..."
-   (std::string mangling on )
 +}
 ```
 
 <!-- TODO: Impl details:
 - Fill in <comment> elsewhere in the JSON ABI spec
 - Fill in <time> elsewhere in the JSON ABI spec
-- Disambiguate the other issue kinds without any associated values: known issue not recorded, api misuse, system
 -->
 
 ### Sample JSON output
@@ -217,7 +225,7 @@ targeted interoperability needs to be updated to read the error from the
   may interoperate with languages which do (e.g. Objective-C, Java). The `error`
   field in the issue metadata may be a good candidate to place exception
   metadata, but exceptions do not share many of the same fields (code, domain,
-  type) as errors in Swift.
+  type) as errors derived from `NSError` in Foundation.
 
 ## Alternatives considered
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -6,7 +6,7 @@
 - Status: **Awaiting implementation**
 - Implementation:
   [swiftlang/swift-testing#NNNNN](https://github.com/swiftlang/swift-testing/pull/NNNNN)
-- Review: ([pitch](https://forums.swift.org/...))
+- Review: ([pitch](https://forums.swift.org/t/pitch-add-issue-fields-to-json-abi-schema/88898))
 
 ## Introduction
 
@@ -16,6 +16,8 @@ an event which includes a limited amount of issue metadata. We propose enriching
 this metadata with additional fields.
 
 ## Motivation
+
+### Provide richer issue metadata for tools
 
 Tools such as Xcode and VS Code can consume the "issue recorded" event from
 Swift Testing's JSON event stream and use that to present test failure details
@@ -63,27 +65,35 @@ weren't available in a machine-readable form:
 
 - **Error:** an error was thrown.
 
-- **Miscount:** a miscount of something led to this issue. Currently, Swift
-  Testing will fill this if a confirmation was confirmed more/fewer times than
+- **Confirmation miscount:** a confirmation was confirmed more/fewer times than
   expected.
-
-<!-- TODO: Consider a more specific field name e.g. "confirmationMiscount"-->
 
 - **Time limit:** the test exceeded a time limit. The unit is seconds, which
   follows the precedent set in an
   [earlier event stream proposal](./0019-include-tags-bugs-and-timeline-in-event-stream.md).
 
-<!-- TODO: Not sure if it would just be better to keep this field as non-optional -->
-
-- **Known issue comment:** if an [issue was marked as known][known-issues] with
-  a human-readable comment, it is included as the value of the existing
-  `"isKnown"` field.
-
-[known-issues]: https://developer.apple.com/documentation/Testing/known-issues
-
 - **Expression:** the expression associated with the issue. This is primarily
   used to capture the body of a failed expectation. However, it can also
   describe a confirmation that was miscounted.
+
+Modify these pre-existing fields:
+
+- **Known issue with optional comment:** whether this issue is a [known
+  issue][known-issues]. This field becomes optional, and resolves to false by
+  default. If an issue was marked as known with a human-readable comment, the
+  field contains the comment instead of a boolean.
+
+[known-issues]: https://developer.apple.com/documentation/Testing/known-issues
+
+- **Messages:** in the context of issues, this field contains human-readable
+  descriptions of the failure. But, after adding the issue fields in this
+  proposal, tools can reconstruct a human-readable description from the updated
+  structure. Therefore, this field becomes optional and will no longer be
+  included by default to avoid the performance cost of generating and
+  serializing this redundant field.
+
+  Tools can continue to receive messages in the event stream using the
+  environment variable `SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED`.
 
 The following field is added for all events:
 
@@ -92,6 +102,9 @@ The following field is added for all events:
   For issues, users can supply comments when recording issues or creating
   expectations, e.g. `Issue.record("A comment")` or
   `#expect(a == b, "A comment")`.
+
+  User-provided comments for `withKnownIssue` are not included here, and are
+  instead included in the `isKnown` field.
 
 ### Schema changes
 
@@ -121,8 +134,6 @@ New common data types:
 
 Events changes:
 
-<!-- TODO: fill out justification for messages -->
-
 ```diff
 <event> ::= {
 ...
@@ -135,7 +146,7 @@ Events changes:
  ...
 +  ["expression": <expression>,] ; an expression associated with the issue
 +  ["error": <error>,] ; the associated error, if any
-+  ["miscount": <miscount>,] ; an associated miscount (too high or too low)
++  ["confirmationMiscount": <miscount>,] ; an associated confirmation miscount (too high or too low)
 +  ["exceededTimeLimit": <time>,] ; the time limit, in seconds, that was exceeded
 -  "isKnown": <bool>,
 +  ["isKnown": <bool> | <comment>] ; whether the issue is known (optionally, the comment associated with the known issue)
@@ -190,7 +201,6 @@ names nor, in most implementations, mangled names.
 - Hard to disambiguate the withKnownIssue not matched
 - We might need to support exclusive bounds since the confirmation range is a RangeExpression which could be a Range and not just a ClosedRange
 -->
-
 <!-- TODO: Need example of mangled name in output as well? -->
 
 <!--
@@ -229,11 +239,14 @@ There are no source compatibility concerns.
 
 ## Integration with supporting tools
 
-The definition of the `isKnown` field will change from the 6.4 schema. It will
-no longer be a required boolean-valued field, and will instead be an optional
-boolean-valued or string-valued field.
+Changes from the 6.4 schema:
 
-All other fields are purely additive to the JSON ABI.
+- `isKnown` will no longer be a required boolean-valued field, and will instead
+  be an optional boolean-valued or string-valued field.
+
+- `messages` field becomes optional.
+
+- All other fields are purely additive to the JSON ABI.
 
 Existing tools that integrate with Swift Testing will need to update their
 integration code to read the new fields. For example, the implementation of
@@ -287,8 +300,8 @@ library, and not all tools that consume test events support all the issue kinds
 that the testing library emits.
 
 Furthermore, tools can derive the same information that issue kind provides by
-inspecting the issue fields. For example, presence of an `miscount` field
-indicates this issue was the "confirmationMiscounted" kind.
+inspecting the issue fields. For example, presence of an `confirmationMiscount`
+field indicates this issue was the "confirmationMiscounted" kind.
 
 ## Acknowledgments
 

--- a/proposals/testing/nnnn-add-issue-metadata-event-stream.md
+++ b/proposals/testing/nnnn-add-issue-metadata-event-stream.md
@@ -131,8 +131,7 @@ New common data types:
   their respective concepts throughout the schema. In the future, we could
   easily change the definition of these types to more complex nested structures.
 
-- `numeric-range` is limited, for simplicity, to representing inclusive bounds.
-  Both bounds, if present, must be integer-valued, otherwise they are ignored.
+- `numeric-range` represents inclusive bounds.
 
 ```diff
 +<comment> ::= <string> ; human-readable, developer-supplied text
@@ -140,8 +139,8 @@ New common data types:
 +<time> ::= <number> ; a timestamp or duration expressed in (floating-point) seconds
 
 +<numeric-range> ::= {
-+  ["min": <number>,] ; lower-bound, inclusive
-+  ["max": <number>] ; upper-bound, inclusive, must be ≥ min (if present)
++  ["min": <integer>,] ; lower-bound, inclusive
++  ["max": <integer>] ; upper-bound, inclusive, must be ≥ min (if present)
 +}
 ```
 
@@ -166,15 +165,15 @@ Events changes:
 }
 
 +<error> ::= {
-+  ["code": <number>,]
++  ["code": <integer>,]
 +  ["domain": <string>,]
 +  ["description": <string>,]
 +  ["type": <type-info>]
 +}
 
 +<miscount> ::= {
-+  "actual": <number>, ; integer-valued actual confirmation count
-+  "expected": <number> ; when the confirmation specifies a single count
++  "actual": <integer>, ; actual confirmation count
++  "expected": <integer> ; when the confirmation specifies a single count
 +            | <numeric-range> ; when the confirmation specifies a range
 +}
 
@@ -188,14 +187,6 @@ Events changes:
 +<expression-value> ::= <string> ; a description of the value
 
 ```
-
-<!-- TODO
-+                       | <number> ; the value, if numeric
-Support for numeric values? For integer values, it might be confusing to have
-them appear as floats (e.g. 5 -> 5.0) after the conversion to a JS number. For
-simplicity, keep the expression value as a description of the value (e.g. 5 ->
-"5" for numerics)
--->
 
 `type-info` will support types from all languages, not just Swift, so only
 applicable fields will be present. For example, C doesn't have fully qualified
@@ -211,47 +202,261 @@ names nor, in most implementations, mangled names.
 
 ### Sample JSON output
 
-<!-- TODO: Impl details:
-- Fill in <comment> elsewhere in the JSON ABI spec
-- Fill in <time> elsewhere in the JSON ABI spec
--->
+<!-- TODO: Impl details: Fill in <comment>, <time>, <integer> elsewhere in the JSON ABI spec -->
 
-<!-- TODO: after demo impl is ready -->
-<!--TODO: open qs:
-- Hard to disambiguate the withKnownIssue not matched
-- We might need to support exclusive bounds since the confirmation range is a RangeExpression which could be a Range and not just a ClosedRange
--->
-<!-- TODO: Need example of mangled name in output as well? -->
+#### Issue recorded with user comment
 
-<!--
+`Issue.record("Issue recorded with user comment")`
 
-```swift
-Issue.record("Issue recorded with user comment")
+```
+{
+  "kind": "event",
+  "payload": {
+    "comments": [
+      "Issue recorded with user comment"
+    ],
+    "instant": { ... },
+    "issue": {
+      "isFailure": true,
+      "severity": "error",
+      "sourceLocation": { ... }
+    },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Issue record`()/SampleTests.swift:3:2"
+  },
+  "version": "6.5.0"
+}
 ```
 
-```swift
-#expect(Bool(false), "Expectation fail with user comment")
-```
+#### Thrown error
 
 ```swift
 struct SampleError: Error {}
 throw SampleError()
 ```
 
-#### Known Issue
-
-```swift
-withKnownIssue("This issue is known") {
-  Issue.record("Some failure")
+```
+{
+  "kind": "event",
+    "payload": {
+      "comments": [],
+      "instant": { ... },
+      "issue": {
+        "error": {
+          "code": 1,
+          "description": "SampleError()",
+          "domain": "SampleTests.(unknown context at $109ada6ac).(unknown context at $109ada6b8).SampleError",
+          "type": {
+            "fullyQualifiedName": "SampleTests.SampleError",
+            "mangledName": "$s11SampleTests10$109ada6acyXZ10$109ada6b8yXZ0A5ErrorV",
+            "unqualifiedName": "SampleError"
+          }
+        },
+        "isFailure": true,
+        "severity": "error",
+        "sourceLocation": { ... }
+      },
+      "iteration": 1,
+      "kind": "issueRecorded",
+      "testID": "SampleTests.`Thrown error`()/SampleTests.swift:11:2"
+    },
+    "version": "6.5.0"
 }
 ```
 
-```swift
-withKnownIssue("Expected an issue but none recorded") {
-  // Intentionally blank with nothing to match
+#### Expectation failure with expression
+
+`#expect(Bool(false), "Expectation fail with user comment")`
+
+```
+{
+  "kind": "event",
+    "payload": {
+      "comments": [
+        "Expectation fail with user comment"
+      ],
+      "instant": { ... },
+      "issue": {
+        "expression": {
+          "children": [
+          {
+            "sourceCode": "false",
+            "type": {
+              "fullyQualifiedName": "()",
+              "mangledName": "$syt",
+              "unqualifiedName": "()"
+            },
+            "value": "()"
+          }
+          ],
+            "sourceCode": "Bool(false)",
+            "type": {
+              "fullyQualifiedName": "Swift.Bool",
+              "mangledName": "$sSb",
+              "unqualifiedName": "Bool"
+            },
+            "value": "false"
+        },
+        "isFailure": true,
+        "severity": "error",
+        "sourceLocation": { ... }
+      },
+      "iteration": 1,
+      "kind": "issueRecorded",
+      "testID": "SampleTests.`Expectation failed`()/SampleTests.swift:7:2"
+    },
+    "version": "6.5.0"
 }
 ```
--->
+
+#### Test timeout: `@Test(.timeLimit(.minutes(1)))`
+
+```
+{
+  "kind": "event",
+    "payload": {
+      "comments": [],
+      "instant": { ... },
+      "issue": {
+        "exceededTimeLimit": 60,
+        "isFailure": true,
+        "severity": "error",
+        "sourceLocation": { ... }
+      },
+      "iteration": 1,
+      "kind": "issueRecorded",
+      "testID": "SampleTests.`Time limit exceeded`()/SampleTests.swift:46:2"
+    },
+    "version": "6.5.0"
+}
+```
+
+#### Known Issues
+
+##### Known issue that is matched
+
+```swift
+withKnownIssue("This matches and doesn't fail") {
+    Issue.record("This is the known issue")
+}
+```
+
+```
+{
+  "kind": "event",
+    "payload": {
+      "comments": [
+        "This is the known issue"
+      ],
+      "instant": { ... },
+      "issue": {
+        "isFailure": false,
+        "isKnown": "This matches and doesn't fail",
+        "severity": "error",
+        "sourceLocation": { ... }
+      },
+      "iteration": 1,
+      "kind": "issueRecorded",
+      "testID": "SampleTests.`Known issue, matched`()/SampleTests.swift:16:2"
+    },
+    "version": "6.5.0"
+}
+```
+
+##### Known issue NOT matched
+
+```swift
+withKnownIssue("This doesn't match and thus fails") {
+    // Intentionally empty
+}
+```
+
+```
+{
+  "kind": "event",
+    "payload": {
+      "comments": [
+        "This doesn't match and thus fails"
+      ],
+      "instant": { ... },
+      "issue": {
+        "isFailure": true,
+        "severity": "error",
+        "sourceLocation": { ... }
+      },
+      "iteration": 1,
+      "kind": "issueRecorded",
+      "testID": "SampleTests.`Known issue, NOT matched`()/SampleTests.swift:22:2"
+    },
+    "version": "6.5.0"
+}
+```
+
+#### Confirmation Miscount
+
+##### Single expected count
+
+`await confirmation { _ in }`
+
+```
+{
+  "kind": "event",
+    "payload": {
+      "comments": [],
+      "instant": { ... },
+      "issue": {
+        "confirmationMiscount": {
+          "actual": 0,
+          "expected": 1
+        },
+        "isFailure": true,
+        "severity": "error",
+        "sourceLocation": { ... }
+      },
+      "iteration": 1,
+      "kind": "issueRecorded",
+      "testID": "SampleTests.`Confirmation miscount, expected single`()/SampleTests.swift:42:2"
+    },
+    "version": "6.5.0"
+}
+```
+
+##### Ranged of expected counts
+
+```swift
+await confirmation(expectedCount: 1...5) { confirmation in
+    for _ in 0..<10 {
+        confirmation()
+    }
+}
+```
+
+```
+{
+  "kind": "event",
+  "payload": {
+    "comments": [],
+    "instant": { ... },
+    "issue": {
+      "confirmationMiscount": {
+        "actual": 10,
+        "expected": {
+          "max": 5,
+          "min": 1
+        }
+      },
+      "isFailure": true,
+      "severity": "error",
+      "sourceLocation": { ... }
+    },
+    "iteration": 1,
+    "kind": "issueRecorded",
+    "testID": "SampleTests.`Confirmation miscount, expected range`()/SampleTests.swift:34:2"
+  },
+  "version": "6.5.0"
+}
+```
 
 ## Source compatibility
 


### PR DESCRIPTION
Opening as draft for preliminary comments.

View [rendered proposal](https://github.com/jerryjrchen/swift-evolution/blob/update-issue-json-abi/proposals/testing/0029-add-issue-metadata-event-stream.md).