### PR TITLE
0540: apply behavioral feedback changes

### DIFF
--- a/proposals/0540-default-target-settings.md
+++ b/proposals/0540-default-target-settings.md
@@ -157,17 +157,17 @@ public final class Package {
     platforms: [SupportedPlatform]? = nil,
     pkgConfig: String? = nil,
     providers: [SystemPackageProvider]? = nil,
+    defaultSwiftSettings: [SwiftSetting] = [],
+    defaultCSettings: [CSetting] = [],
+    defaultCXXSettings: [CXXSetting] = [],
+    defaultLinkerSettings: [LinkerSetting] = []
     products: [Product] = [],
     traits: Set<Trait> = [],
     dependencies: [Dependency] = [],
     targets: [Target] = [],
     swiftLanguageVersions: [SwiftVersion]? = nil,
-    defaultSwiftSettings: [SwiftSetting] = [],
     cLanguageStandard: CLanguageStandard? = nil,
-    defaultCSettings: [CSetting] = [],
     cxxLanguageStandard: CXXLanguageStandard? = nil,
-    defaultCXXSettings: [CXXSetting] = [],
-    defaultLinkerSettings: [LinkerSetting] = []
   )
 }
 ```
@@ -176,7 +176,7 @@ public final class Package {
 struct SwiftSetting {
   // ...
   
-  public static func inherited() -> SwiftSetting {
+  public static var defaults: SwiftSetting {
     // ...
   }
 }
@@ -184,7 +184,7 @@ struct SwiftSetting {
 struct CSetting {
   // ...
   
-  public static func inherited() -> CSetting {
+  public static var defaults: CSetting {
     // ...
   }
 }
@@ -192,7 +192,7 @@ struct CSetting {
 struct CXXSetting {
   // ...
   
-  public static func inherited() -> CXXSettings {
+  public static var defaults: CXXSettings {
     // ...
   }
 }
@@ -200,7 +200,7 @@ struct CXXSetting {
 struct LinkerSetting {
   // ...
   
-  public static func inherited() -> LinkerSetting {
+  public static var defaults: LinkerSetting {
     // ...
   }
 }
@@ -211,6 +211,9 @@ With these changes in place, the default package template could look like this:
 ```swift
 let package = Package(
   // ...
+  defaultSwiftSettings: [
+    .enableUpcomingFeature("ApproachableConcurrency"),
+  ],
   targets: [
     .target(
       name: "MyPackage"
@@ -219,9 +222,6 @@ let package = Package(
       name: "MyPackageTests",
       dependencies: ["MyPackage"]
     ),
-  ],
-  defaultSwiftSettings: [
-    .enableUpcomingFeature("ApproachableConcurrency"),
   ]
 )
 ```
@@ -229,28 +229,30 @@ let package = Package(
 The swift-configuration definition would see a much more dramatic simplification (with a little help from a ternary expression).
 
 ```swift
-defaultSwiftSettings: [
-  // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-  // Require `any` for existential types.
-  .enableUpcomingFeature("ExistentialAny"),
-  
-  // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
-  .enableUpcomingFeature("MemberImportVisibility"),
-  
-  // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
-  .enableUpcomingFeature("InternalImportsByDefault"),
-  
-  // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
-  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
-  
-  .enableExperimentalFeature(
-    "AvailabilityMacro=Configuration 1.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"
-  ),
-  
-  .unsafeFlags(
-    enableAllCIFlags ? ["-Xfrontend", "-require-explicit-sendable"] : []
-  ),
-]
+// ...
+  defaultSwiftSettings: [
+    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
+    // Require `any` for existential types.
+    .enableUpcomingFeature("ExistentialAny"),
+    
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+    .enableUpcomingFeature("MemberImportVisibility"),
+    
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    
+    // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    
+    .enableExperimentalFeature(
+      "AvailabilityMacro=Configuration 1.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"
+    ),
+    
+    .unsafeFlags(
+      enableAllCIFlags ? ["-Xfrontend", "-require-explicit-sendable"] : []
+    ),
+  ]
+// ...
 ```
 
 It completely eliminates the array and target mutations.
@@ -260,7 +262,7 @@ This makes the file feel much more declarative.
 ### Settings Inheritance
 
 It is important that it be possible to control defaults on a per-target basis.
-This is supported with a new `inherited` placeholder setting.
+This is supported with a new `defaults` placeholder setting.
 When setting are evaluated, this placeholder is substituted with the corresponding default values.
 
 Here are four possible target configurations that demonstrate the functionality.
@@ -268,6 +270,9 @@ Here are four possible target configurations that demonstrate the functionality.
 ```swift
 let package = Package(
   // ...
+  defaultSwiftSettings: [
+    .enableUpcomingFeature("ApproachableConcurrency"),
+  ],
   targets: [
     .target(
       name: "A",
@@ -275,7 +280,7 @@ let package = Package(
     .target(
       name: "B",
       swiftSettings: [
-        .inherited(),
+        .defaults,
       ]
     ),
     .target(
@@ -286,20 +291,17 @@ let package = Package(
     .target(
       name: "D",
       swiftSettings: [
-        .inherited(),
+        .defaults,
         .enableExperimentalFeature("Lifetimes"),
       ]
     ),
-  ],
-  defaultSwiftSettings: [
-    .enableUpcomingFeature("ApproachableConcurrency"),
   ]
 )
 ```
 
 - Target `A`: `swiftSettings` is omitted, so defaults apply
-- Target `B`: explicitly opts into inheriting the defaults
-- Target `C`: defines settings without inheriting, no defaults are applied
+- Target `B`: explicitly opts into applying the defaults
+- Target `C`: defines settings without usig `defaults`, no defaults are applied
 - Target `D`: defines settings that control the order of the inheritance
 
 The behavior is identical for the `cSettings`, `cxxSettings`, and `linkerSettings` properties.
@@ -316,7 +318,7 @@ In many cases, this results in "last entry wins" semantics.
 
 Default settings can have conditions, just like regular target settings.
 Supporting and resolving this correctly represents considerable additional complexity.
-For now, the `inherited` placeholder setting itself does not accept conditions.
+For now, the `defaults` placeholder setting itself cannot accept conditions.
 
 ## Source compatibility
 
@@ -338,18 +340,24 @@ Authors will be able to adopt default settings freely without concern for compat
 
 ## Future directions
 
-Conditional inheritance could also be something that package authors find useful.
+Conditional defaults could also be something that package authors find useful.
 It would be possible to add support for this in an API-compatible way.
 
 ## Alternatives considered
 
 An earlier version of this proposal suggested an automatic,
-predefined merging strategy without the `inherited` placeholder.
+predefined merging strategy without the `defaults` placeholder.
 
 With some settings, such as `defaultIsolation`,
 the results of a merge seem quite unambiguous.
 But, this is not the case for all values, and the merging logic can be involved.
-The `inherited` mechanism is both intuitive and more powerful.
+The `defaults` mechanism is both intuitive and more powerful.
+
+Choosing the appropriate ordering for the defaults parameters in `Package.init`
+is not straightforward.
+The original implementation attempted to group this with other, related parameters.
+This might be logical, but it does shift the defaults to later,
+resulting in use before definition.
 
 ## Acknowledgments
 

--- a/proposals/0540-default-target-settings.md
+++ b/proposals/0540-default-target-settings.md
@@ -130,7 +130,104 @@ The desired configuration for the vast majority of package authors is the same.
 Begin with a core list of settings that define baseline behaviors,
 along with per-target refinements to that list as needed.
 
-The package manifest API should provide a way to express this directly.
+We can allow the default settings to be defined as a part of the package initializer.
+
+```swift
+let package = Package(
+  // ...
+  defaultSwiftSettings: [
+    .enableUpcomingFeature("ApproachableConcurrency"),
+  ],
+  targets: [
+    .target(
+      name: "MyPackage"
+    ),
+    .testTarget(
+      name: "MyPackageTests",
+      dependencies: ["MyPackage"]
+    ),
+  ]
+)
+```
+
+It is important that it be possible to control defaults on a per-target basis.
+This is supported with a new `defaults` placeholder setting.
+When settings are evaluated, this placeholder is substituted with the corresponding default values.
+
+Here are four possible target configurations that demonstrate the functionality.
+
+```swift
+let package = Package(
+  // ...
+  defaultSwiftSettings: [
+    .enableUpcomingFeature("ApproachableConcurrency"),
+  ],
+  targets: [
+    .target(
+      name: "A",
+    ),
+    .target(
+      name: "B",
+      swiftSettings: [
+        .defaults,
+      ]
+    ),
+    .target(
+      name: "C",
+      swiftSettings: [
+      ]
+    ),
+    .target(
+      name: "D",
+      swiftSettings: [
+        .defaults,
+        .enableExperimentalFeature("Lifetimes"),
+      ]
+    ),
+  ]
+)
+```
+
+- Target `A`: `swiftSettings` is omitted, so defaults apply
+- Target `B`: explicitly opts into applying the defaults
+- Target `C`: defines settings without using `defaults`, no defaults are applied
+- Target `D`: defines settings that control the order of the inheritance
+
+The behavior would be identical for the `cSettings`, `cxxSettings`, and `linkerSettings` properties.
+
+With all these changes in place,
+the swift-configuration definition would see a substantial simplification (with a little help from a ternary expression).
+
+```swift
+// ...
+  defaultSwiftSettings: [
+    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
+    // Require `any` for existential types.
+    .enableUpcomingFeature("ExistentialAny"),
+    
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+    .enableUpcomingFeature("MemberImportVisibility"),
+    
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    
+    // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    
+    .enableExperimentalFeature(
+      "AvailabilityMacro=Configuration 1.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"
+    ),
+    
+    .unsafeFlags(
+      enableAllCIFlags ? ["-Xfrontend", "-require-explicit-sendable"] : []
+    ),
+  ]
+// ...
+```
+
+This proposal would completely eliminate the array and target mutations.
+Plus, it helps to establish a more obvious connection between the definition and the settings.
+This makes the file feel much more declarative.
 
 ## Detailed design
 
@@ -206,105 +303,7 @@ struct LinkerSetting {
 }
 ```
 
-With these changes in place, the default package template could look like this:
-
-```swift
-let package = Package(
-  // ...
-  defaultSwiftSettings: [
-    .enableUpcomingFeature("ApproachableConcurrency"),
-  ],
-  targets: [
-    .target(
-      name: "MyPackage"
-    ),
-    .testTarget(
-      name: "MyPackageTests",
-      dependencies: ["MyPackage"]
-    ),
-  ]
-)
-```
-
-The swift-configuration definition would see a much more dramatic simplification (with a little help from a ternary expression).
-
-```swift
-// ...
-  defaultSwiftSettings: [
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-    // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny"),
-    
-    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
-    .enableUpcomingFeature("MemberImportVisibility"),
-    
-    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
-    .enableUpcomingFeature("InternalImportsByDefault"),
-    
-    // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
-    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
-    
-    .enableExperimentalFeature(
-      "AvailabilityMacro=Configuration 1.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"
-    ),
-    
-    .unsafeFlags(
-      enableAllCIFlags ? ["-Xfrontend", "-require-explicit-sendable"] : []
-    ),
-  ]
-// ...
-```
-
-It completely eliminates the array and target mutations.
-Plus, it helps to establish a more obvious connection between the definition and the settings.
-This makes the file feel much more declarative.
-
 ### Settings Inheritance
-
-It is important that it be possible to control defaults on a per-target basis.
-This is supported with a new `defaults` placeholder setting.
-When setting are evaluated, this placeholder is substituted with the corresponding default values.
-
-Here are four possible target configurations that demonstrate the functionality.
-
-```swift
-let package = Package(
-  // ...
-  defaultSwiftSettings: [
-    .enableUpcomingFeature("ApproachableConcurrency"),
-  ],
-  targets: [
-    .target(
-      name: "A",
-    ),
-    .target(
-      name: "B",
-      swiftSettings: [
-        .defaults,
-      ]
-    ),
-    .target(
-      name: "C",
-      swiftSettings: [
-      ]
-    ),
-    .target(
-      name: "D",
-      swiftSettings: [
-        .defaults,
-        .enableExperimentalFeature("Lifetimes"),
-      ]
-    ),
-  ]
-)
-```
-
-- Target `A`: `swiftSettings` is omitted, so defaults apply
-- Target `B`: explicitly opts into applying the defaults
-- Target `C`: defines settings without usig `defaults`, no defaults are applied
-- Target `D`: defines settings that control the order of the inheritance
-
-The behavior is identical for the `cSettings`, `cxxSettings`, and `linkerSettings` properties.
 
 For compatibility with conditional compilation,
 empty default settings arrays are accepted and do not have any special meaning.


### PR DESCRIPTION
This makes a few changes that affect behavior:

- `func inherited()` -> `var defaults`
- the positioning of default settings has been moved earlier in the initializer definition