### PR TITLE
Fix incorrect filename for SE-0542 in proposal link

### DIFF
--- a/proposals/0542-package-manager-conditional-plugin.md
+++ b/proposals/0542-package-manager-conditional-plugin.md
@@ -1,6 +1,6 @@
 # Package Manager Conditional Plugin
 
-* Proposal: [SE-0542](0542-package-manager-conditionals.md)
+* Proposal: [SE-0542](0542-package-manager-conditional-plugin.md)
 * Authors: [Clive Liu](https://github.com/clive819)
 * Review Manager: [David Cummings](https://github.com/daveyc123)
 * Status: **Active Review (August 6th - August 21st)**


### PR DESCRIPTION
This PR corrects the filename in the proposal link for SE-0542.

The incorrect link causes a 404 error when clicking the proposal on the evolution dashboard instead of navigating to the proposal.

I have also filed an issue for the metadata extractor tool to validate the filename to catch similar errors in the future. https://github.com/swiftlang/swift-evolution-metadata-extractor/issues/124