### PR TITLE
Address SE-0546 validation warning by fixing review dates

### DIFF
--- a/proposals/0546-memberwise-init-extensions.md
+++ b/proposals/0546-memberwise-init-extensions.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0546](0546-memberwise-init-extensions.md)
 * Authors: [Stephen Celis](https://github.com/stephencelis), [Brandon Williams](https://github.com/mbrandonw)
 * Review Manager: [Stephen Canon](https://github.com/stephentyrone)
-* Status: **Active Review (Aug 21...Sep 4, 2026)**
+* Status: **Active Review (August 21...September 4, 2026)**
 * Implementation: [swiftlang/swift#90710](https://github.com/swiftlang/swift/pull/90710)
 * Review: ([pitch](https://forums.swift.org/t/same-file-memberwise-initializer-extensions/88466))([review](https://forums.swift.org/t/se-0546-same-file-memberwise-initializer-extensions/89120))
 


### PR DESCRIPTION
Updates the review dates so the metadata extractor tool will parse them.

The CI validation did detect the formatting issue, but the issue was reported as it was in the legacy version of the tool, as a warning, not an error, so the CI validation passed.

Have also filed issue with the extractor tool to promote the warning to error.
https://github.com/swiftlang/swift-evolution-metadata-extractor/issues/128