### PR TITLE
Normalize review dates

### DIFF
--- a/proposals/0542-package-manager-conditional-plugin.md
+++ b/proposals/0542-package-manager-conditional-plugin.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0542](0542-package-manager-conditional-plugin.md)
 * Authors: [Clive Liu](https://github.com/clive819)
 * Review Manager: [David Cummings](https://github.com/daveyc123)
-* Status: **Active Review (August 6th - August 21st)**
+* Status: **Active Review (August 6 - August 21)**
 * Implementation: [swiftlang/swift-package-manager#10119](https://github.com/swiftlang/swift-package-manager/pull/10119)
 * Review: ([pitch](https://forums.swift.org/t/pitch-package-manager-conditional-plugin/86217)) ([review](https://forums.swift.org/t/se-0542-package-manager-condition-plugins/88820))
 

--- a/proposals/0545-build-debugging-options.md
+++ b/proposals/0545-build-debugging-options.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0545](0545-build-debugging-options.md)
 * Authors: [Owen Voorhees](https://github.com/owenv)
 * Review Manager: [Mishal Shah](https://github.com/shahmishal)
-* Status: **Active Review (August 12th...26th, 2026)**
+* Status: **Active Review (August 12...26, 2026)**
 * Implementation: Nightly snapshot toolchains via experimental flags `--experimental-trace-events-file` and `--experimental-task-backtraces`
 * Review: ([pitch](https://forums.swift.org/t/pitch-swiftpm-build-performance-debugging-options/87369)) ([review](https://forums.swift.org/t/se-0545-swiftpm-build-performance-debugging-options/88943))
 

--- a/proposals/0547-swiftpm-compilation-caching.md
+++ b/proposals/0547-swiftpm-compilation-caching.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0547](0547-swiftpm-compilation-caching.md)
 * Authors: [Owen Voorhees](https://github.com/owenv)
 * Review Manager: [Mishal Shah](https://github.com/shahmishal)
-* Status: **Active Review (August 25th...September 1st, 2026)**
+* Status: **Active Review (August 25...September 1, 2026)**
 * Implementation: [PR #10246](https://github.com/swiftlang/swift-package-manager/pull/10246)
 * Review: ([pitch](https://forums.swift.org/t/pitch-compilation-caching-support-in-swiftpm/88079)) ([review](https://forums.swift.org/t/se-0547-swiftpm-support-for-compilation-caching/89191))
 


### PR DESCRIPTION
Make days cardinal instead of ordinal numbers to pass upcoming validation.

The legacy validation of review date ranges incorrectly allowed ordinal numbers like '24th'.  An upcoming validation enhancement will catch this case in the near future. Changing these files so all current proposals will pass the enhanced validation.

// @shahmishal 