### PR TITLE
SE-0542 Add year to review period

### DIFF
--- a/proposals/0542-package-manager-conditional-plugin.md
+++ b/proposals/0542-package-manager-conditional-plugin.md
@@ -3,7 +3,7 @@
 * Proposal: [SE-0542](0542-package-manager-conditional-plugin.md)
 * Authors: [Clive Liu](https://github.com/clive819)
 * Review Manager: [David Cummings](https://github.com/daveyc123)
-* Status: **Active Review (August 6 - August 21)**
+* Status: **Active Review (August 6 - August 21, 2026)**
 * Implementation: [swiftlang/swift-package-manager#10119](https://github.com/swiftlang/swift-package-manager/pull/10119)
 * Review: ([pitch](https://forums.swift.org/t/pitch-package-manager-conditional-plugin/86217)) ([review](https://forums.swift.org/t/se-0542-package-manager-condition-plugins/88820))
 


### PR DESCRIPTION
Adds a year to the review period.

A missing year will be a validation error in the near future.

// @shahmishal 