### PR TITLE
[SE-0546] Allow default `init()` initializers to be written in extensions

### DIFF
--- a/proposals/0546-memberwise-init-extensions.md
+++ b/proposals/0546-memberwise-init-extensions.md
@@ -89,7 +89,8 @@ extension Post {
 A handwritten initializer that is indistinguishable from the synthesized
 initializer (_i.e._ it has the same argument names and types defined in the
 same order) will now suppress the default, synthesized initializer when
-defined in an unconstrained, same-file extension.
+defined in an unconstrained, same-file extension. This includes both memberwise
+and default `init()` initializers.
 
 ## Source compatibility
 


### PR DESCRIPTION
The empty `init()` synthesized initializer is not technically a memberwise initializer, but the same mechanism should allow it to be overridden.